### PR TITLE
feat: add FSDP2 multi-GPU training backend with multi-tenant LoRA support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I"]
-per-file-ignores = {"src/tuft/server.py" = ["B008"]}
+per-file-ignores = {"src/tuft/server.py" = ["B008"], "tests/test_fsdp_*.py" = ["E402", "I001"]}
 
 [tool.ruff.lint.isort]
 known-first-party = ["tuft"]

--- a/src/tuft/backends/__init__.py
+++ b/src/tuft/backends/__init__.py
@@ -1,3 +1,4 @@
+from .fsdp_training_backend import FSDPTrainingBackend
 from .sampling_backend import BaseSamplingBackend, VLLMSamplingBackend
 from .training_backend import BaseTrainingBackend, HFTrainingBackend
 
@@ -7,4 +8,5 @@ __all__ = [
     "VLLMSamplingBackend",
     "BaseTrainingBackend",
     "HFTrainingBackend",
+    "FSDPTrainingBackend",
 ]

--- a/src/tuft/backends/__init__.py
+++ b/src/tuft/backends/__init__.py
@@ -1,4 +1,3 @@
-from .fsdp_training_backend import FSDPTrainingBackend
 from .sampling_backend import BaseSamplingBackend, VLLMSamplingBackend
 from .training_backend import BaseTrainingBackend, HFTrainingBackend
 
@@ -8,5 +7,12 @@ __all__ = [
     "VLLMSamplingBackend",
     "BaseTrainingBackend",
     "HFTrainingBackend",
-    "FSDPTrainingBackend",
 ]
+
+
+def __getattr__(name: str):  # noqa: N807
+    if name == "FSDPTrainingBackend":
+        from .fsdp_training_backend import FSDPTrainingBackend
+
+        return FSDPTrainingBackend
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/tuft/backends/base_backend.py
+++ b/src/tuft/backends/base_backend.py
@@ -110,6 +110,10 @@ class BaseTrainingBackend(BaseBackend):
             from ..backends.training_backend import DummyTrainingBackend
 
             return DummyTrainingBackend(config)
+        elif config.training_backend == "fsdp":
+            from ..backends.fsdp_training_backend import FSDPTrainingBackend
+
+            return FSDPTrainingBackend(config)
         else:
             from ..backends.training_backend import HFTrainingBackend
 

--- a/src/tuft/backends/fsdp_training_backend.py
+++ b/src/tuft/backends/fsdp_training_backend.py
@@ -1,0 +1,108 @@
+"""FSDP2 multi-GPU training backend for TuFT.
+
+Implements :class:`BaseTrainingBackend` by delegating all work to an
+:class:`FSDPWorkerGroup`.  The ``TrainingController`` sees this as an
+ordinary backend — adapter management, forward/backward, optimizer
+steps, and checkpoint operations are all routed transparently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tinker import types
+
+from tuft.backends.base_backend import BaseTrainingBackend
+from tuft.backends.fsdp_worker_group import FSDPWorkerGroup
+from tuft.checkpoints import CheckpointRecord
+from tuft.config import ModelConfig
+from tuft.telemetry.tracing import get_tracer
+
+
+_get_tracer = lambda: get_tracer("tuft.fsdp_training_backend")  # noqa: E731
+logger = logging.getLogger(__name__)
+
+
+class FSDPTrainingBackend(BaseTrainingBackend):
+    """Multi-GPU FSDP2 training backend."""
+
+    def __init__(self, config: ModelConfig) -> None:
+        super().__init__(config)
+        logger.info(
+            "Creating FSDPTrainingBackend: %s (%d GPUs × %d nodes)",
+            config.model_name,
+            config.num_gpus_per_node,
+            config.num_nodes,
+        )
+        self.worker_group = FSDPWorkerGroup(
+            config,
+            num_gpus_per_node=config.num_gpus_per_node,
+            num_nodes=config.num_nodes,
+        )
+
+    async def async_init(self) -> None:
+        pass
+
+    async def create_adapter(self, lora_id: str, lora_config: types.LoraConfig) -> None:
+        with _get_tracer().start_as_current_span("fsdp_backend.create_adapter") as span:
+            span.set_attribute("tuft.lora_id", lora_id)
+            span.set_attribute("tuft.lora_rank", lora_config.rank)
+            self.worker_group.create_adapter_all(lora_id, lora_config)
+
+    async def remove_adapter(self, lora_id: str) -> None:
+        with _get_tracer().start_as_current_span("fsdp_backend.remove_adapter"):
+            self.worker_group.remove_adapter_all(lora_id)
+
+    async def forward(
+        self,
+        data: list[types.Datum],
+        lora_id: str,
+        loss_fn: types.LossFnType,
+        loss_fn_config: dict[str, float] | None,
+        backward: bool = False,
+    ) -> types.ForwardBackwardOutput:
+        span_name = "fsdp_backend.forward_backward" if backward else "fsdp_backend.forward"
+        with _get_tracer().start_as_current_span(span_name) as span:
+            span.set_attribute("tuft.lora_id", lora_id)
+            span.set_attribute("tuft.backward", backward)
+            span.set_attribute("tuft.data_count", len(data))
+            return self.worker_group.forward_all(data, lora_id, loss_fn, loss_fn_config, backward)
+
+    async def optim_step(
+        self,
+        adam_params: types.AdamParams,
+        lora_id: str,
+    ) -> types.OptimStepResponse:
+        with _get_tracer().start_as_current_span("fsdp_backend.optim_step") as span:
+            span.set_attribute("tuft.lora_id", lora_id)
+            return self.worker_group.optim_step_all(adam_params, lora_id)
+
+    async def save_state(
+        self,
+        lora_id: str,
+        checkpoint_record: CheckpointRecord,
+        optimizer: bool,
+    ) -> None:
+        with _get_tracer().start_as_current_span("fsdp_backend.save_state") as span:
+            span.set_attribute("tuft.lora_id", lora_id)
+            span.set_attribute("tuft.optimizer", optimizer)
+            self.worker_group.save_state_all(lora_id, checkpoint_record, optimizer)
+
+    async def load_state(
+        self,
+        lora_id: str,
+        checkpoint_record: CheckpointRecord,
+        optimizer: bool,
+    ) -> None:
+        with _get_tracer().start_as_current_span("fsdp_backend.load_state") as span:
+            span.set_attribute("tuft.lora_id", lora_id)
+            span.set_attribute("tuft.optimizer", optimizer)
+            self.worker_group.load_state_all(lora_id, checkpoint_record, optimizer)
+
+    async def get_memory_stats(self) -> list[dict]:
+        """Collect GPU memory statistics from all FSDP workers."""
+        return self.worker_group.get_memory_stats_all()
+
+    def shutdown(self) -> None:
+        """Shut down the FSDP backend and release GPU resources."""
+        self.worker_group.shutdown()

--- a/src/tuft/backends/fsdp_training_worker.py
+++ b/src/tuft/backends/fsdp_training_worker.py
@@ -1,0 +1,606 @@
+"""FSDP2 Training Worker — one instance per GPU.
+
+Handles model construction, FSDP2 wrapping, and multi-tenant adapter
+management with forward/backward/optimizer operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING, Any, Dict
+
+import torch
+import torch.distributed
+from peft import LoraConfig, get_peft_model
+from tinker import types
+from tinker.types import LoraConfig as TinkerLoraConfig
+from torch.nn.utils.rnn import pad_sequence
+from transformers import AutoModelForCausalLM
+
+from tuft.backends.fsdp_utils import (
+    FSDPModule,  # type: ignore[reportPrivateImportUsage]
+    MixedPrecisionPolicy,  # type: ignore[reportPrivateImportUsage]
+    apply_fsdp2,
+    create_device_mesh,
+    fsdp2_clip_grad_norm_,
+)
+from tuft.backends.hf_training_model import get_target_modules
+from tuft.checkpoints import CheckpointRecord
+from tuft.config import ModelConfig
+from tuft.loss_fn import get_loss_fn, metrics_reduction
+
+
+if TYPE_CHECKING:
+    from torch.distributed.tensor import DTensor
+else:
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        from torch.distributed._tensor import DTensor  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_decoder_layer_linears(model: torch.nn.Module) -> list[str] | str:
+    """Return the short names of all ``nn.Linear`` modules that live inside
+    transformer decoder layers (identified via ``_no_split_modules``).
+
+    This gives a comprehensive target_modules list for the "default" LoRA
+    adapter so that all possible target modules are pre-wrapped *before*
+    FSDP2 sharding.
+    """
+    no_split = set()
+    for m in (model, getattr(model, "model", None)):
+        ns = getattr(m, "_no_split_modules", None)
+        if ns:
+            no_split.update(ns)
+    if not no_split:
+        no_split = {"DecoderLayer"}
+
+    in_decoder_layer = set()
+    for _name, mod in model.named_modules():
+        if mod.__class__.__name__ in no_split:
+            for sub_name, sub_mod in mod.named_modules():
+                if isinstance(sub_mod, torch.nn.Linear):
+                    in_decoder_layer.add(sub_name.split(".")[-1])
+            break
+
+    return sorted(in_decoder_layer) if in_decoder_layer else "all-linear"
+
+
+class FSDPTrainingWorker:
+    """Single-GPU FSDP2 training worker.
+
+    Each Ray actor wraps one instance.  All workers in the same
+    :class:`FSDPWorkerGroup` share an NCCL process group and jointly hold
+    one FSDP2-sharded model.
+
+    Multi-tenant design
+    -------------------
+    *   Each adapter has its own ``AdamW`` optimizer and gradient buffer.
+    *   When switching adapters, the *entire* gradient state of the active
+        adapter (all ``requires_grad`` params) is saved and restored so that
+        gradient accumulation across ``forward_backward`` calls is seamless.
+    *   Optimizer states (momentum / variance) live inside per-adapter
+        ``AdamW`` instances and are never affected by adapter switches.
+    """
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
+    def __init__(
+        self,
+        config: ModelConfig,
+        rank: int,
+        world_size: int,
+        master_addr: str,
+        master_port: int,
+    ) -> None:
+        self.config = config
+        self.rank = rank
+        self.world_size = world_size
+
+        # --- 1. distributed setup ---
+        os.environ["MASTER_ADDR"] = master_addr
+        os.environ["MASTER_PORT"] = str(master_port)
+        local_rank = rank % torch.cuda.device_count()
+        torch.cuda.set_device(local_rank)
+
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(
+                backend="cpu:gloo,cuda:nccl",
+                rank=rank,
+                world_size=world_size,
+            )
+
+        # --- 2. device mesh ---
+        self.device_mesh = create_device_mesh(world_size=world_size, fsdp_size=-1)
+
+        # --- 3. build model ---
+        self.model: torch.nn.Module = self._build_fsdp2_model(config)
+
+        # --- 4. multi-tenant state ---
+        self.adapter_optimizer: Dict[str, torch.optim.AdamW] = {}
+        self.saved_grads: Dict[str, Dict[str, torch.Tensor]] = {}
+        self.has_pending_grads: Dict[str, bool] = {}
+        self.active_adapter: str | None = None
+        self.micro_batch_size = config.micro_batch_size
+
+        logger.info("FSDPTrainingWorker rank=%d ready (world_size=%d)", rank, world_size)
+
+    def cleanup(self) -> None:
+        """Release GPU resources and destroy the distributed process group.
+
+        Must be called before killing the actor to allow the next worker group
+        to initialise a new process group on the same GPUs.
+        """
+        del self.model
+        self.adapter_optimizer.clear()
+        self.saved_grads.clear()
+        torch.cuda.empty_cache()
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+        logger.info("FSDPTrainingWorker rank=%d cleaned up", self.rank)
+
+    @property
+    def _peft(self) -> Any:
+        """Access PEFT-specific methods (add_adapter, set_adapter, etc.)
+        on the FSDP2-wrapped PeftModel without pyright complaints about
+        nn.Module's dynamic __getattr__ return type.
+        """
+        return self.model
+
+    # ------------------------------------------------------------------
+    # Model construction
+    # ------------------------------------------------------------------
+    def _build_fsdp2_model(self, config: ModelConfig) -> torch.nn.Module:
+        model = AutoModelForCausalLM.from_pretrained(
+            str(config.model_path),
+            torch_dtype=torch.bfloat16,
+        )
+        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+
+        # Wrap ALL decoder-layer linear modules with a placeholder LoRA
+        # *before* FSDP2 sharding.  This ensures later add_adapter calls
+        # only invoke PEFT's update_layer (adding weights to existing
+        # ModuleDicts) instead of _replace_module, which would break
+        # FSDP2's parameter tracking.
+        #
+        # autocast_adapter_dtype=False prevents PEFT from up-casting
+        # bfloat16 LoRA weights to float32, keeping all parameters in a
+        # consistent dtype for mixed-precision training.
+        model.enable_input_require_grads()
+        default_targets = _detect_decoder_layer_linears(model)
+        peft_config = LoraConfig(target_modules=default_targets)
+        model = get_peft_model(
+            model,
+            peft_config=peft_config,
+            adapter_name="default",
+            autocast_adapter_dtype=False,
+        )
+
+        torch.distributed.barrier()
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            cast_forward_inputs=True,
+        )
+        fsdp_kwargs = {
+            "mesh": self.device_mesh,
+            "mp_policy": mp_policy,
+            "reshard_after_forward": True,
+        }
+        apply_fsdp2(model, fsdp_kwargs)
+
+        if not isinstance(model, FSDPModule):
+            raise RuntimeError("FSDP2 wrapping failed — model is not FSDPModule")
+        torch.distributed.barrier()
+        result: torch.nn.Module = model  # type: ignore[assignment]
+        return result
+
+    # ------------------------------------------------------------------
+    # Adapter management
+    # ------------------------------------------------------------------
+    def create_adapter(
+        self,
+        lora_id: str,
+        lora_config: TinkerLoraConfig,
+    ) -> None:
+        if lora_id in self.adapter_optimizer:
+            raise ValueError(f"Adapter {lora_id} already exists.")
+
+        target_mods = get_target_modules(str(self.config.model_path), lora_config)
+        peft_config = LoraConfig(
+            r=lora_config.rank,
+            target_modules=target_mods,
+            lora_alpha=lora_config.rank,
+        )
+        self._peft.add_adapter(adapter_name=lora_id, peft_config=peft_config)
+        self._peft.set_adapter(lora_id)
+
+        # PEFT's _move_adapter_to_device_of_base_layer infers dtype from the
+        # base weight (DTensor bfloat16).  Enforce bfloat16 explicitly in case
+        # PEFT's internal logic changes, and broadcast from rank 0 so every
+        # rank starts with identical LoRA weights (FSDP2 does not manage these
+        # dynamically-added parameters).
+        torch.distributed.barrier()
+        for p in self.model.parameters():
+            if p.requires_grad and not isinstance(p.data, DTensor):
+                if p.data.dtype != torch.bfloat16:
+                    p.data = p.data.to(torch.bfloat16)
+                torch.distributed.broadcast(p.data, src=0)
+        torch.distributed.barrier()
+
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        self.adapter_optimizer[lora_id] = torch.optim.AdamW(params)
+        self.active_adapter = lora_id
+
+    def remove_adapter(self, lora_id: str) -> None:
+        if lora_id in self.adapter_optimizer:
+            self._peft.delete_adapter(lora_id)
+            del self.adapter_optimizer[lora_id]
+            self.saved_grads.pop(lora_id, None)
+            self.has_pending_grads.pop(lora_id, None)
+            if self.active_adapter == lora_id:
+                self.active_adapter = None
+            torch.cuda.empty_cache()
+
+    # ------------------------------------------------------------------
+    # Gradient save / restore for multi-tenant isolation
+    # ------------------------------------------------------------------
+    def _save_adapter_grads(self, adapter_id: str) -> None:
+        """Snapshot the gradient of every trainable param for *adapter_id*."""
+        grads: Dict[str, torch.Tensor] = {}
+        for name, param in self.model.named_parameters():
+            if param.requires_grad and param.grad is not None:
+                grads[name] = param.grad.detach().clone()
+        self.saved_grads[adapter_id] = grads
+
+    def _restore_adapter_grads(self, adapter_id: str) -> None:
+        """Restore previously saved gradients for *adapter_id*."""
+        saved = self.saved_grads.get(adapter_id)
+        if saved is None:
+            return
+        for name, param in self.model.named_parameters():
+            if param.requires_grad and name in saved:
+                param.grad = saved[name]
+
+    def _zero_active_grads(self) -> None:
+        """Zero out gradients of the currently trainable parameters."""
+        for param in self.model.parameters():
+            if param.requires_grad and param.grad is not None:
+                param.grad = None
+
+    def _clear_saved_grads(self, adapter_id: str) -> None:
+        self.saved_grads.pop(adapter_id, None)
+        self.has_pending_grads[adapter_id] = False
+
+    def _switch_adapter(self, target_adapter_id: str) -> None:
+        """Switch the active adapter, persisting / restoring gradients."""
+        if self.active_adapter == target_adapter_id:
+            return
+
+        # save current adapter's grads (if any pending)
+        if self.active_adapter is not None and self.has_pending_grads.get(
+            self.active_adapter, False
+        ):
+            self._save_adapter_grads(self.active_adapter)
+
+        # activate target
+        self._peft.set_adapter(target_adapter_id)
+        self.active_adapter = target_adapter_id
+
+        # restore target adapter's grads
+        if self.has_pending_grads.get(target_adapter_id, False):
+            self._restore_adapter_grads(target_adapter_id)
+        else:
+            self._zero_active_grads()
+
+    # ------------------------------------------------------------------
+    # Training: forward / backward
+    # ------------------------------------------------------------------
+    def forward(
+        self,
+        data_shard: list[types.Datum],
+        lora_id: str,
+        loss_fn: types.LossFnType,
+        loss_fn_config: dict[str, float] | None,
+        backward: bool,
+    ) -> types.ForwardBackwardOutput:
+        """Forward (and optionally backward) on a data shard."""
+        self._switch_adapter(lora_id)
+
+        loss_fn_callable = get_loss_fn(loss_fn)
+        batch_size = len(data_shard)
+        micro_batch_size = self.micro_batch_size
+        num_micro_batches = max(1, (batch_size + micro_batch_size - 1) // micro_batch_size)
+
+        all_loss_fn_outputs: list[dict] = []
+        micro_batch_weights: list[float] = []
+        metric_list: list[dict] = []
+        total_loss = 0.0
+
+        for micro_idx in range(num_micro_batches):
+            start = micro_idx * micro_batch_size
+            end = min(start + micro_batch_size, batch_size)
+            micro_data = data_shard[start:end]
+
+            micro_loss, micro_metrics, micro_outputs = self._forward_micro_batch(
+                micro_data, loss_fn_callable, loss_fn_config, backward
+            )
+            total_loss += micro_loss
+            all_loss_fn_outputs.extend(micro_outputs)
+            micro_batch_weights.append(len(micro_outputs))
+            metric_list.append(micro_metrics)
+            torch.cuda.empty_cache()
+
+        if backward:
+            self.has_pending_grads[lora_id] = True
+
+        reduced_metrics = metrics_reduction(metric_list, micro_batch_weights)
+
+        return types.ForwardBackwardOutput(
+            loss_fn_output_type=loss_fn,
+            loss_fn_outputs=all_loss_fn_outputs,
+            metrics=reduced_metrics or {},
+        )
+
+    def _forward_micro_batch(
+        self,
+        data: list[types.Datum],
+        loss_fn_callable,
+        loss_fn_config: dict[str, float] | None,
+        backward: bool,
+    ) -> tuple[float, dict, list[dict]]:
+        """Process one micro-batch."""
+        input_ids = [torch.tensor(d.model_input.to_ints(), dtype=torch.long) for d in data]
+        input_ids_padded = pad_sequence(input_ids, batch_first=True, padding_value=0)
+        attention_mask = (input_ids_padded != 0).long()
+        position_ids = (
+            torch.arange(input_ids_padded.size(1), dtype=torch.long)
+            .unsqueeze(0)
+            .expand(input_ids_padded.size(0), -1)
+        )
+
+        device = torch.cuda.current_device()
+        input_ids_padded = input_ids_padded.to(device)
+        attention_mask = attention_mask.to(device)
+        position_ids = position_ids.to(device)
+
+        outputs = self.model(
+            input_ids=input_ids_padded,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            return_dict=True,
+        )
+
+        if loss_fn_config is None:
+            loss_fn_config = {}
+
+        logits = outputs.logits
+        del outputs
+        torch.cuda.empty_cache()
+
+        if "temperature" in loss_fn_config:
+            logits = logits / loss_fn_config["temperature"]
+
+        loss_fn_inputs = self._prepare_loss_fn_inputs(data)
+        target_tokens = loss_fn_inputs["target_tokens"]
+        target_logprobs = self._compute_logprobs_from_target_tokens(logits, target_tokens)
+        del logits
+        torch.cuda.empty_cache()
+
+        loss_fn_inputs["target_logprobs"] = target_logprobs
+        loss, metric = loss_fn_callable(loss_fn_inputs, loss_fn_config)
+
+        if backward:
+            loss.backward(retain_graph=False)
+            torch.cuda.empty_cache()
+
+        unpadded = self._unpad_tensor(
+            target_logprobs.detach(),
+            [len(d.model_input.to_ints()) for d in data],
+        )
+        loss_fn_outputs = [
+            {"logprobs": types.TensorData.from_torch(lp.cpu().clone())} for lp in unpadded
+        ]
+
+        loss_value = loss.detach().item()
+        del target_logprobs, unpadded, loss_fn_inputs, loss
+        torch.cuda.empty_cache()
+
+        return loss_value, metric, loss_fn_outputs
+
+    # ------------------------------------------------------------------
+    # Training: optimizer step
+    # ------------------------------------------------------------------
+    def optim_step(
+        self,
+        adam_params: types.AdamParams,
+        lora_id: str,
+    ) -> types.OptimStepResponse:
+        """Optimizer step with manual gradient synchronization for LoRA params."""
+        self._switch_adapter(lora_id)
+
+        optimizer = self.adapter_optimizer[lora_id]
+        for pg in optimizer.param_groups:
+            pg["lr"] = adam_params.learning_rate
+            pg["betas"] = (adam_params.beta1, adam_params.beta2)
+            pg["eps"] = adam_params.eps
+            pg["weight_decay"] = adam_params.weight_decay
+
+        # LoRA adapter parameters live outside FSDP2 sharding (regular
+        # tensors, not DTensors).  FSDP2 only reduces gradients of sharded
+        # parameters.  We must AllReduce the LoRA gradients so every rank
+        # applies the same optimizer update and parameters stay in sync.
+        for p in self.model.parameters():
+            if p.requires_grad and p.grad is not None and not isinstance(p.grad, DTensor):
+                torch.distributed.all_reduce(p.grad, op=torch.distributed.ReduceOp.AVG)
+
+        trainable = [p for p in self.model.parameters() if p.requires_grad]
+        if adam_params.grad_clip_norm > 0:
+            grad_norm = fsdp2_clip_grad_norm_(trainable, max_norm=adam_params.grad_clip_norm)
+        else:
+            grads = [p.grad for p in trainable if p.grad is not None]
+            if grads:
+                grad_norm = torch.stack([g.detach().norm(2) for g in grads]).norm(2)
+            else:
+                grad_norm = torch.tensor(0.0)
+
+        if isinstance(grad_norm, DTensor):
+            grad_norm = grad_norm.full_tensor()
+
+        if not torch.isfinite(grad_norm):
+            logger.warning("grad_norm is not finite (%s), skipping update", grad_norm)
+            optimizer.zero_grad()
+        else:
+            optimizer.step()
+
+        optimizer.zero_grad()
+        self._clear_saved_grads(lora_id)
+        torch.cuda.empty_cache()
+        return types.OptimStepResponse()
+
+    # ------------------------------------------------------------------
+    # Checkpoint save / load
+    # ------------------------------------------------------------------
+    def save_state(
+        self,
+        lora_id: str,
+        checkpoint_record: CheckpointRecord,
+        optimizer_flag: bool,
+    ) -> None:
+        if self.rank == 0:
+            adapter_dir = checkpoint_record.adapter_path
+            adapter_dir.mkdir(parents=True, exist_ok=True)
+            self._peft.save_pretrained(str(adapter_dir), selected_adapters=[lora_id])
+            lora_subdir = adapter_dir / lora_id
+            if lora_subdir.exists() and lora_subdir.is_dir():
+                for item in lora_subdir.iterdir():
+                    dest = adapter_dir / item.name
+                    if dest.exists():
+                        if dest.is_file():
+                            dest.unlink()
+                        elif dest.is_dir():
+                            shutil.rmtree(dest)
+                    shutil.move(str(item), str(dest))
+                lora_subdir.rmdir()
+
+        if optimizer_flag and lora_id in self.adapter_optimizer:
+            opt_dir = checkpoint_record.optimizer_path
+            opt_dir.mkdir(parents=True, exist_ok=True)
+            opt_path = opt_dir / f"optimizer_rank_{self.rank}.pt"
+            torch.save(self.adapter_optimizer[lora_id].state_dict(), opt_path)
+
+        torch.distributed.barrier()
+
+    def load_state(
+        self,
+        lora_id: str,
+        checkpoint_record: CheckpointRecord,
+        optimizer_flag: bool,
+    ) -> None:
+        adapter_dir = checkpoint_record.adapter_path
+        self._peft.load_adapter(str(adapter_dir), adapter_name=lora_id)
+
+        self._peft.set_adapter(lora_id)
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(params)
+
+        if optimizer_flag:
+            opt_path = checkpoint_record.optimizer_path / f"optimizer_rank_{self.rank}.pt"
+            if not opt_path.exists():
+                legacy = checkpoint_record.optimizer_path / f"{lora_id}_rank_{self.rank}.pt"
+                if legacy.exists():
+                    opt_path = legacy
+            if opt_path.exists():
+                optimizer.load_state_dict(
+                    torch.load(opt_path, map_location="cpu", weights_only=True)
+                )
+        self.adapter_optimizer[lora_id] = optimizer
+        self.active_adapter = lora_id
+
+        torch.distributed.barrier()
+
+    # ------------------------------------------------------------------
+    # GPU memory reporting
+    # ------------------------------------------------------------------
+    def get_memory_stats(self) -> dict:
+        """Return GPU memory statistics for this worker's device."""
+        device = torch.cuda.current_device()
+        return {
+            "rank": self.rank,
+            "device": device,
+            "allocated_mb": round(torch.cuda.memory_allocated(device) / 1024**2, 1),
+            "reserved_mb": round(torch.cuda.memory_reserved(device) / 1024**2, 1),
+            "max_allocated_mb": round(torch.cuda.max_memory_allocated(device) / 1024**2, 1),
+        }
+
+    def get_adapter_param_fingerprint(self, lora_id: str) -> dict:
+        """Fingerprint of adapter params for cross-rank consistency checks."""
+        self._switch_adapter(lora_id)
+        total = 0.0
+        count = 0
+        for p in self.model.parameters():
+            if p.requires_grad:
+                t = p.data
+                if isinstance(t, DTensor):
+                    t = t.full_tensor()
+                total += t.float().sum().item()
+                count += t.numel()
+        return {"rank": self.rank, "param_sum": total, "param_count": count}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _prepare_loss_fn_inputs(self, data: list[types.Datum]) -> dict[str, torch.Tensor]:
+        device = torch.cuda.current_device()
+        loss_fn_input_dict: dict[str, torch.Tensor] = {}
+        loss_fn_input_keys = data[0].loss_fn_inputs.keys()
+        for key in loss_fn_input_keys:
+            tensors = [datum.loss_fn_inputs[key].to_torch() for datum in data]
+            if all(t.dim() == 1 for t in tensors):
+                padded = pad_sequence(tensors, batch_first=True, padding_value=0)
+                loss_fn_input_dict[key] = padded.to(device)
+            else:
+                try:
+                    stacked = torch.stack(tensors)
+                    loss_fn_input_dict[key] = stacked.to(device)
+                except Exception:
+                    max_shape = list(tensors[0].shape)
+                    for t in tensors:
+                        for i, s in enumerate(t.shape):
+                            if s > max_shape[i]:
+                                max_shape[i] = s
+                    padded_tensors = []
+                    for t in tensors:
+                        pad_width = [(0, m - s) for s, m in zip(t.shape, max_shape, strict=False)]
+                        pad_args: list[int] = []
+                        for p in reversed(pad_width):
+                            pad_args.extend(p)
+                        padded_tensors.append(torch.nn.functional.pad(t, pad_args, value=0))
+                    stacked = torch.stack(padded_tensors)
+                    loss_fn_input_dict[key] = stacked.to(device)
+        return loss_fn_input_dict
+
+    def _compute_logprobs_from_target_tokens(
+        self, logits: torch.Tensor, target_tokens: torch.Tensor
+    ) -> torch.Tensor:
+        if logits.dtype in (torch.float32, torch.float64):
+            logits_labels = torch.gather(logits, dim=-1, index=target_tokens.unsqueeze(-1)).squeeze(
+                -1
+            )
+            logsumexp_values = torch.stack([torch.logsumexp(logit, dim=-1) for logit in logits])
+            return logits_labels - logsumexp_values
+        log_probs_labels = []
+        for row_logits, row_labels in zip(logits, target_tokens, strict=True):
+            row_lp = torch.nn.functional.log_softmax(row_logits, dim=-1)
+            row_lp_labels = row_lp.gather(dim=-1, index=row_labels.unsqueeze(-1)).squeeze(-1)
+            log_probs_labels.append(row_lp_labels)
+        return torch.stack(log_probs_labels)
+
+    def _unpad_tensor(self, padded: torch.Tensor, lengths: list[int]) -> list[torch.Tensor]:
+        return [padded[i, :length] for i, length in enumerate(lengths)]

--- a/src/tuft/backends/fsdp_utils.py
+++ b/src/tuft/backends/fsdp_utils.py
@@ -93,9 +93,9 @@ def _resolve_no_split_modules(model: nn.Module) -> list[str]:
     if no_split:
         return list(no_split)
 
-    inner: nn.Module = model
+    inner: object = model
     while hasattr(inner, "model"):
-        inner = inner.model
+        inner = inner.model  # type: ignore[union-attr]
         no_split = getattr(inner, "_no_split_modules", None)
         if no_split:
             return list(no_split)

--- a/src/tuft/backends/fsdp_utils.py
+++ b/src/tuft/backends/fsdp_utils.py
@@ -1,0 +1,277 @@
+"""FSDP2 utility functions for TuFT multi-GPU training."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from contextlib import contextmanager
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from packaging import version
+from torch.distributed.device_mesh import init_device_mesh
+
+
+# ---------------------------------------------------------------------------
+# Version-aware imports
+# ---------------------------------------------------------------------------
+if version.parse(torch.__version__) >= version.parse("2.6"):
+    from torch.distributed.fsdp import (  # noqa: F401 — re-exported
+        CPUOffloadPolicy,
+        FSDPModule,
+        MixedPrecisionPolicy,
+        fully_shard,
+    )
+    from torch.distributed.fsdp._fully_shard import _fully_shard as _fully_shard_module
+    from torch.distributed.tensor import Shard
+elif version.parse(torch.__version__) >= version.parse("2.4"):
+    from torch.distributed._composable.fsdp import (  # noqa: F401
+        CPUOffloadPolicy,  # pyright: ignore[reportPrivateImportUsage]
+        FSDPModule,  # pyright: ignore[reportPrivateImportUsage]
+        MixedPrecisionPolicy,  # pyright: ignore[reportPrivateImportUsage]
+        fully_shard,  # pyright: ignore[reportPrivateImportUsage]
+    )
+
+    _fully_shard_module = torch.distributed._composable.fsdp  # type: ignore[attr-defined]
+    from torch.distributed.tensor import Shard
+else:
+    raise RuntimeError("FSDP2 requires PyTorch >= 2.4")
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Handles ABC compatibility when applying fully_shard to HuggingFace models.
+# ---------------------------------------------------------------------------
+@contextmanager
+def maybe_patch_fsdp_module(model: nn.Module):
+    orig_fsdp_module = _fully_shard_module.FSDPModule
+
+    class _FSDPModuleABC(ABC, orig_fsdp_module):  # type: ignore[misc]
+        pass
+
+    try:
+        if isinstance(model, ABC):
+            _fully_shard_module.FSDPModule = _FSDPModuleABC
+        yield
+    finally:
+        _fully_shard_module.FSDPModule = orig_fsdp_module
+
+
+# ---------------------------------------------------------------------------
+# Wraps transformer sub-modules then root with fully_shard.
+# ---------------------------------------------------------------------------
+def apply_fsdp2(model: nn.Module, fsdp_kwargs: dict) -> None:
+    """Apply FSDP2 sharding to a HuggingFace-style model.
+
+    Wraps each transformer layer (identified by ``_no_split_modules``) and
+    standalone ``nn.Embedding`` layers, then wraps the root module.
+    """
+    no_split_modules = _resolve_no_split_modules(model)
+
+    tie_word_embeddings = getattr(getattr(model, "config", None), "tie_word_embeddings", True)
+
+    modules_to_shard: list[nn.Module] = []
+    for _name, module in model.named_modules():
+        if module.__class__.__name__ in no_split_modules:
+            modules_to_shard.append(module)
+        elif isinstance(module, nn.Embedding) and not tie_word_embeddings:
+            modules_to_shard.append(module)
+
+    for module in modules_to_shard:
+        with maybe_patch_fsdp_module(module):
+            fully_shard(module, **fsdp_kwargs)
+
+    with maybe_patch_fsdp_module(model):
+        fully_shard(model, **fsdp_kwargs)
+
+
+def _resolve_no_split_modules(model: nn.Module) -> list[str]:
+    """Walk through possible wrapper layers (e.g. PeFT) to find _no_split_modules."""
+    no_split = getattr(model, "_no_split_modules", None)
+    if no_split:
+        return list(no_split)
+
+    inner: nn.Module = model
+    while hasattr(inner, "model"):
+        inner = inner.model
+        no_split = getattr(inner, "_no_split_modules", None)
+        if no_split:
+            return list(no_split)
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Loads a full state dict (rank 0 only) into FSDP2-sharded model via DCP.
+# ---------------------------------------------------------------------------
+def fsdp2_load_full_state_dict(
+    model: nn.Module,
+    full_state: dict,
+    device_mesh=None,
+    cpu_offload=None,
+) -> None:
+    """Broadcast full state dict from rank 0 into FSDP2-sharded model.
+
+    Directly calls ``set_model_state_dict`` on the already-FSDP2-wrapped model
+    with ``broadcast_from_rank0=True`` — rank 0 provides the full state dict
+    while other ranks pass an empty dict.
+    """
+    from torch.distributed.checkpoint.state_dict import (
+        StateDictOptions,
+        set_model_state_dict,
+    )
+
+    options = StateDictOptions(
+        full_state_dict=True,
+        broadcast_from_rank0=True,
+    )
+
+    if dist.get_rank() == 0:
+        set_model_state_dict(model, full_state, options=options)
+    else:
+        set_model_state_dict(model, {}, options=options)
+
+    for _name, buf in model.named_buffers():
+        if buf.device.type != "cuda":
+            buf.data = buf.data.to(torch.cuda.current_device())
+        dist.broadcast(buf, src=0)
+
+
+# ---------------------------------------------------------------------------
+# Collect the full state dict from an FSDP2 model.
+# ---------------------------------------------------------------------------
+def get_fsdp2_full_state_dict(
+    model: nn.Module, offload_to_cpu: bool = True, rank0_only: bool = True
+) -> dict:
+    """Collect the full state dict from an FSDP2 model via DCP."""
+    from torch.distributed.checkpoint.state_dict import (
+        StateDictOptions,
+        get_model_state_dict,
+    )
+
+    options = StateDictOptions(
+        full_state_dict=True,
+        cpu_offload=offload_to_cpu,
+        broadcast_from_rank0=not rank0_only,
+    )
+    return get_model_state_dict(model, options=options)
+
+
+# ---------------------------------------------------------------------------
+# Gradient clipping compatible with FSDP2 DTensor parameters.
+# ---------------------------------------------------------------------------
+def fsdp2_clip_grad_norm_(
+    parameters,
+    max_norm: float,
+    norm_type: float = 2.0,
+    error_if_nonfinite: bool = False,
+    foreach=None,
+) -> torch.Tensor:
+    """Gradient clipping that works with FSDP2 DTensor parameters."""
+    from torch.nn.utils.clip_grad import _clip_grads_with_norm_, _get_total_norm
+
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    else:
+        parameters = list(parameters)
+    grads = [p.grad for p in parameters if p.grad is not None]
+    total_norm = _get_total_norm(grads, norm_type, error_if_nonfinite, foreach)
+    total_norm = total_norm.to(torch.cuda.current_device(), non_blocking=True)
+    _clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
+    return total_norm
+
+
+# ---------------------------------------------------------------------------
+# DeviceMesh helpers.
+# ---------------------------------------------------------------------------
+def create_device_mesh(world_size: int, fsdp_size: int = -1):
+    """Create a 1-D or 2-D device mesh for FSDP2.
+
+    Args:
+        world_size: total number of ranks.
+        fsdp_size: FSDP group size. If -1 or >= world_size, use pure FSDP
+            (all ranks in one dimension). Otherwise use HSDP (DDP x FSDP).
+    """
+    if fsdp_size < 0 or fsdp_size >= world_size:
+        return init_device_mesh("cuda", mesh_shape=(world_size,), mesh_dim_names=("fsdp",))
+    return init_device_mesh(
+        "cuda",
+        mesh_shape=(world_size // fsdp_size, fsdp_size),
+        mesh_dim_names=("ddp", "fsdp"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model offload helpers.
+# ---------------------------------------------------------------------------
+@torch.no_grad()
+def offload_fsdp2_model_to_cpu(model: nn.Module, empty_cache: bool = True) -> None:
+    model.cpu()
+    if empty_cache:
+        torch.cuda.empty_cache()
+
+
+@torch.no_grad()
+def load_fsdp2_model_to_gpu(model: nn.Module) -> None:
+    model.to(torch.cuda.current_device())
+
+
+# ---------------------------------------------------------------------------
+# Optimizer offload helpers.
+# ---------------------------------------------------------------------------
+@torch.no_grad()
+def offload_fsdp_optimizer(optimizer: torch.optim.Optimizer) -> None:
+    if not optimizer.state:
+        return
+    for param_group in optimizer.param_groups:
+        for param in param_group["params"]:
+            state = optimizer.state[param]
+            for key, value in state.items():
+                if isinstance(value, torch.Tensor):
+                    state[key] = value.to("cpu", non_blocking=True)
+
+
+@torch.no_grad()
+def load_fsdp_optimizer(optimizer: torch.optim.Optimizer, device) -> None:
+    if not optimizer.state:
+        return
+    for param_group in optimizer.param_groups:
+        for param in param_group["params"]:
+            state = optimizer.state[param]
+            for key, value in state.items():
+                if isinstance(value, torch.Tensor):
+                    state[key] = value.to(device, non_blocking=True)
+
+
+# ---------------------------------------------------------------------------
+# Shard placement function.
+# ---------------------------------------------------------------------------
+def get_shard_placement_fn(fsdp_size: int):
+    """Return a placement function that shards on a dimension divisible by fsdp_size."""
+
+    def _fn(param: torch.Tensor):
+        for i, s in enumerate(param.shape):
+            if s % fsdp_size == 0:
+                return Shard(i)
+        return Shard(0)
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# FSDP version detection.
+# ---------------------------------------------------------------------------
+def fsdp_version(model: nn.Module) -> int:
+    """Return 1 for FSDP1, 2 for FSDP2, 0 for neither."""
+    if isinstance(model, FSDPModule):
+        return 2
+    try:
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        if isinstance(model, FSDP):
+            return 1
+    except ImportError as exc:
+        logger.debug("FSDP1 import unavailable: %s", exc)
+    return 0

--- a/src/tuft/backends/fsdp_worker_group.py
+++ b/src/tuft/backends/fsdp_worker_group.py
@@ -1,0 +1,259 @@
+"""FSDPWorkerGroup — manages multiple FSDPTrainingWorker Ray actors."""
+
+from __future__ import annotations
+
+import logging
+import socket
+from typing import Any
+
+import ray
+from ray.util.placement_group import (
+    PlacementGroupSchedulingStrategy,
+    placement_group,
+)
+from tinker import types
+
+from tuft.config import ModelConfig
+from tuft.loss_fn import metrics_reduction
+
+
+logger = logging.getLogger(__name__)
+
+
+class FSDPWorkerGroup:
+    """Create and coordinate a group of ``FSDPTrainingWorker`` Ray actors."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        num_gpus_per_node: int,
+        num_nodes: int = 1,
+    ) -> None:
+        self.config = config
+        self.total_gpus = num_gpus_per_node * num_nodes
+        self.num_gpus_per_node = num_gpus_per_node
+        self.num_nodes = num_nodes
+        self.workers: list[Any] = []
+
+        master_addr, master_port = self._get_master_addr_port()
+
+        # --- placement groups ---
+        pgs = []
+        for _ in range(num_nodes):
+            bundles = [{"GPU": 1, "CPU": 1}] * num_gpus_per_node
+            pg = placement_group(bundles, strategy="STRICT_PACK")
+            ray.get(pg.ready())
+            pgs.append(pg)
+
+        pgs = self._sort_pgs_by_ip(pgs)
+
+        # --- create worker actors ---
+        from tuft.backends.fsdp_training_worker import FSDPTrainingWorker
+
+        RemoteWorker = ray.remote(num_gpus=1)(FSDPTrainingWorker)
+
+        rank = 0
+        for pg in pgs:
+            for bundle_idx in range(num_gpus_per_node):
+                worker = RemoteWorker.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg,
+                        placement_group_bundle_index=bundle_idx,
+                    ),
+                ).remote(config, rank, self.total_gpus, master_addr, master_port)
+                self.workers.append(worker)
+                rank += 1
+
+        logger.info(
+            "FSDPWorkerGroup created: %d workers across %d nodes",
+            self.total_gpus,
+            num_nodes,
+        )
+
+    # ------------------------------------------------------------------
+    # Collective operations — call every worker and wait
+    # ------------------------------------------------------------------
+    def forward_all(
+        self,
+        data: list[types.Datum],
+        lora_id: str,
+        loss_fn: types.LossFnType,
+        loss_fn_config: dict[str, float] | None,
+        backward: bool,
+    ) -> types.ForwardBackwardOutput:
+        actual_sizes = self._actual_shard_sizes(len(data), self.total_gpus)
+        shards = self._split_data(data, self.total_gpus)
+        futures = [
+            w.forward.remote(shard, lora_id, loss_fn, loss_fn_config, backward)
+            for w, shard in zip(self.workers, shards, strict=True)
+        ]
+        results: list[types.ForwardBackwardOutput] = ray.get(futures)
+        return self._merge_forward_results(results, actual_sizes)
+
+    def optim_step_all(
+        self,
+        adam_params: types.AdamParams,
+        lora_id: str,
+    ) -> types.OptimStepResponse:
+        futures = [w.optim_step.remote(adam_params, lora_id) for w in self.workers]
+        ray.get(futures)
+        return types.OptimStepResponse()
+
+    def create_adapter_all(
+        self,
+        lora_id: str,
+        lora_config: types.LoraConfig,
+    ) -> None:
+        futures = [w.create_adapter.remote(lora_id, lora_config) for w in self.workers]
+        ray.get(futures)
+
+    def remove_adapter_all(self, lora_id: str) -> None:
+        futures = [w.remove_adapter.remote(lora_id) for w in self.workers]
+        ray.get(futures)
+
+    def save_state_all(
+        self,
+        lora_id: str,
+        checkpoint_record: Any,
+        optimizer: bool,
+    ) -> None:
+        futures = [w.save_state.remote(lora_id, checkpoint_record, optimizer) for w in self.workers]
+        ray.get(futures)
+
+    def load_state_all(
+        self,
+        lora_id: str,
+        checkpoint_record: Any,
+        optimizer: bool,
+    ) -> None:
+        futures = [w.load_state.remote(lora_id, checkpoint_record, optimizer) for w in self.workers]
+        ray.get(futures)
+
+    # ------------------------------------------------------------------
+    # Data splitting / result merging
+    # ------------------------------------------------------------------
+    def _split_data(self, data: list[types.Datum], num_shards: int) -> list[list[types.Datum]]:
+        """Distribute datums evenly across shards (DP split).
+
+        All shards are padded to the same size (by repeating the last item)
+        so that every rank performs the same number of model forward calls —
+        a hard requirement for FSDP2 collective operations.
+        """
+        shard_size = max(1, -(-len(data) // num_shards))  # ceil division
+        shards: list[list[types.Datum]] = []
+        for i in range(num_shards):
+            start = i * shard_size
+            end = min(start + shard_size, len(data))
+            shard = list(data[start:end])
+            while len(shard) < shard_size and shard:
+                shard.append(shard[-1])
+            if not shard:
+                shard = [data[-1]]
+            shards.append(shard)
+        return shards
+
+    def _merge_forward_results(
+        self,
+        results: list[types.ForwardBackwardOutput],
+        actual_sizes: list[int] | None = None,
+    ) -> types.ForwardBackwardOutput:
+        all_outputs: list[dict] = []
+        all_metrics: list[dict] = []
+        weights: list[float] = []
+        for idx, result in enumerate(results):
+            n = actual_sizes[idx] if actual_sizes else len(result.loss_fn_outputs)
+            all_outputs.extend(result.loss_fn_outputs[:n])
+            all_metrics.append(result.metrics)
+            weights.append(n)
+
+        merged_metrics = metrics_reduction(all_metrics, weights) if all_metrics else {}
+
+        return types.ForwardBackwardOutput(
+            loss_fn_output_type=results[0].loss_fn_output_type,
+            loss_fn_outputs=all_outputs,
+            metrics=merged_metrics,
+        )
+
+    @staticmethod
+    def _actual_shard_sizes(total: int, num_shards: int) -> list[int]:
+        """Return the real (unpadded) item count for each shard."""
+        shard_size = max(1, -(-total // num_shards))
+        sizes: list[int] = []
+        remaining = total
+        for _ in range(num_shards):
+            n = min(shard_size, remaining)
+            sizes.append(max(n, 0))
+            remaining -= shard_size
+        return sizes
+
+    def get_adapter_param_fingerprint_all(self, lora_id: str) -> list[dict]:
+        """Collect adapter parameter fingerprints from every worker."""
+        futures = [w.get_adapter_param_fingerprint.remote(lora_id) for w in self.workers]
+        return ray.get(futures)
+
+    def get_memory_stats_all(self) -> list[dict]:
+        """Collect GPU memory stats from every worker."""
+        futures = [w.get_memory_stats.remote() for w in self.workers]
+        return ray.get(futures)
+
+    def shutdown(self) -> None:
+        """Gracefully clean up workers, then kill the Ray actors.
+
+        Calls ``cleanup()`` on every worker first to destroy the NCCL
+        process group, allowing subsequent worker groups to initialise
+        new process groups on the same GPUs.
+        """
+        cleanup_futures = []
+        for worker in self.workers:
+            try:
+                cleanup_futures.append(worker.cleanup.remote())
+            except Exception:
+                logger.debug("Failed to schedule cleanup on worker", exc_info=True)
+        if cleanup_futures:
+            try:
+                ray.get(cleanup_futures, timeout=30)
+            except Exception:
+                logger.warning("Timed out waiting for worker cleanup", exc_info=True)
+
+        for worker in self.workers:
+            try:
+                ray.kill(worker)
+            except Exception:
+                logger.debug("Failed to kill worker actor", exc_info=True)
+        self.workers.clear()
+        logger.info("FSDPWorkerGroup shut down — all workers killed")
+
+    # ------------------------------------------------------------------
+    # Infrastructure helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _get_master_addr_port() -> tuple[str, int]:
+        master_addr = ray.util.get_node_ip_address()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            master_port = s.getsockname()[1]
+        return master_addr, master_port
+
+    @staticmethod
+    def _sort_pgs_by_ip(pgs: list) -> list:
+        """Sort placement groups by node IP for deterministic RANK assignment.
+
+        Ensures checkpoint resume works after Ray cluster restarts.
+        """
+        if len(pgs) <= 1:
+            return pgs
+
+        node_info = {n["NodeID"]: n["NodeManagerAddress"] for n in ray.nodes()}
+
+        def _get_pg_ip(pg):
+            try:
+                table = ray._private.state.state.placement_group_table(pg.id)
+                bundles_to_node = table.get("bundles_to_node_id", {})
+                if bundles_to_node:
+                    node_id = next(iter(bundles_to_node.values()))
+                    return node_info.get(node_id, "")
+            except Exception:
+                logger.debug("Could not resolve PG IP", exc_info=True)
+            return ""
+
+        return sorted(pgs, key=_get_pg_ip)

--- a/tests/test_fsdp_comprehensive.py
+++ b/tests/test_fsdp_comprehensive.py
@@ -18,6 +18,10 @@ Requires:
 
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("torch", reason="FSDP tests require PyTorch")
+
 import os
 import tempfile
 import time
@@ -25,7 +29,6 @@ from pathlib import Path
 from typing import Any, List
 
 import numpy as np
-import pytest
 import ray
 import transformers
 from tinker import types

--- a/tests/test_fsdp_comprehensive.py
+++ b/tests/test_fsdp_comprehensive.py
@@ -1,0 +1,548 @@
+"""Comprehensive FSDP2 multi-GPU training test suite.
+
+Covers:
+    1. Single base model with multiple adapters of different LoRA ranks
+    2. Training-state preservation across adapter switches
+       (weights + optimizer momentum are not lost)
+    3. Sequential training on two different base models
+    4. Deploying a trained LoRA adapter to vLLM inference
+    5. GPU memory monitoring throughout every phase
+
+Requires:
+    - ``--gpu`` pytest flag
+    - At least 2 GPUs for FSDP multi-GPU training (FSDP_TEST_GPUS, default 2)
+    - Inference test trains first (2 GPUs), then shuts down and starts vLLM (1 GPU)
+    - ``TUFT_TEST_MODEL`` (or ``FSDP_TEST_MODEL_A``) env var pointing to a model
+    - ``FSDP_TEST_MODEL_B`` env var for sequential multi-model tests (optional)
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, List
+
+import numpy as np
+import pytest
+import ray
+import transformers
+from tinker import types
+
+from tuft.backends.fsdp_training_backend import FSDPTrainingBackend
+from tuft.checkpoints import CheckpointRecord
+from tuft.config import ModelConfig
+
+from .helpers import (
+    PIG_LATIN_EXAMPLES,
+    PIG_LATIN_EXAMPLES_EXTENDED,
+    TEST_PROMPTS,
+    _normalize_text,
+    clear_ray_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model paths — resolved from environment variables only
+# ---------------------------------------------------------------------------
+def _resolve_model_path(env_key: str) -> Path | None:
+    val = os.environ.get(env_key)
+    if val:
+        return Path(val)
+    val = os.environ.get("TUFT_TEST_MODEL")
+    if val:
+        return Path(val)
+    return None
+
+
+MODEL_A_PATH = _resolve_model_path("FSDP_TEST_MODEL_A")
+MODEL_B_PATH = _resolve_model_path("FSDP_TEST_MODEL_B")
+NUM_FSDP_GPUS = max(2, int(os.environ.get("FSDP_TEST_GPUS", "2")))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="function")
+def fsdp_ray_cluster(request):
+    if not request.config.getoption("--gpu"):
+        yield
+        return
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if torch.cuda.device_count() < NUM_FSDP_GPUS:
+        pytest.skip(
+            f"Need at least {NUM_FSDP_GPUS} GPUs for FSDP, found {torch.cuda.device_count()}"
+        )
+    if MODEL_A_PATH is None:
+        pytest.skip("TUFT_TEST_MODEL / FSDP_TEST_MODEL_A not set")
+    clear_ray_state()
+    ray.init(ignore_reinit_error=True)
+    yield
+    clear_ray_state()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_config(model_path: Path | None, **overrides) -> ModelConfig:
+    assert model_path is not None, "Model path must be set via environment variable"
+    defaults: dict[str, Any] = dict(
+        model_name=model_path.name,
+        model_path=model_path,
+        max_model_len=2048,
+        tensor_parallel_size=1,
+        training_backend="fsdp",
+        num_gpus_per_node=NUM_FSDP_GPUS,
+        num_nodes=1,
+        max_lora_rank=32,
+    )
+    defaults.update(overrides)
+    return ModelConfig(**defaults)
+
+
+def _construct_data(model_path: Path | None, name: str = "extended") -> List[types.Datum]:
+    assert model_path is not None, "Model path must be set via environment variable"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
+    examples = PIG_LATIN_EXAMPLES_EXTENDED if name == "extended" else PIG_LATIN_EXAMPLES
+    data = []
+    for example in examples:
+        prompt = f"English: {example['input']}\nPig Latin:"
+        prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+        prompt_weights = [0] * len(prompt_tokens)
+        completion_tokens = tokenizer.encode(f" {example['output']}\n\n", add_special_tokens=False)
+        completion_weights = [1] * len(completion_tokens)
+        tokens = prompt_tokens + completion_tokens
+        weights = prompt_weights + completion_weights
+        input_tokens = tokens[:-1]
+        target_tokens = tokens[1:]
+        weights = weights[1:]
+        data.append(
+            types.Datum(
+                model_input=types.ModelInput.from_ints(tokens=input_tokens),
+                loss_fn_inputs=dict(
+                    weights=types.TensorData(data=weights, dtype="float32"),
+                    target_tokens=types.TensorData(data=target_tokens, dtype="int64"),
+                ),
+            )
+        )
+    return data
+
+
+def _compute_loss(output: types.ForwardBackwardOutput, data) -> float:
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+    logprobs = np.concatenate([o["logprobs"].tolist() for o in output.loss_fn_outputs])
+    return float(-np.dot(logprobs, weights) / weights.sum())
+
+
+async def _train_step(
+    backend: FSDPTrainingBackend,
+    data,
+    lora_id: str,
+    lr: float = 1e-4,
+) -> float:
+    """One forward-backward + optim-step; returns the loss."""
+    output = await backend.forward(
+        data=data,
+        lora_id=lora_id,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=True,
+    )
+    await backend.optim_step(types.AdamParams(learning_rate=lr), lora_id=lora_id)
+    return _compute_loss(output, data)
+
+
+async def _forward_only(
+    backend: FSDPTrainingBackend,
+    data,
+    lora_id: str,
+) -> float:
+    """Forward pass without backward — returns the loss."""
+    output = await backend.forward(
+        data=data,
+        lora_id=lora_id,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=False,
+    )
+    return _compute_loss(output, data)
+
+
+def _print_memory(stats: list[dict], tag: str) -> None:
+    for s in stats:
+        print(
+            f"  [{tag}] rank {s['rank']}  "
+            f"alloc={s['allocated_mb']:.0f}MB  "
+            f"reserved={s['reserved_mb']:.0f}MB  "
+            f"peak={s['max_allocated_mb']:.0f}MB",
+            flush=True,
+        )
+
+
+# ===================================================================
+# Test 1 — Multi-adapter training with different LoRA ranks
+# ===================================================================
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_multi_adapter_different_ranks(fsdp_ray_cluster):
+    """Create adapters with rank 4, 8, 16 on one model.
+    Train each and verify loss decreases.  Monitor GPU memory growth.
+    """
+    config = _make_config(MODEL_A_PATH)
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_A_PATH)
+
+    mem_init = await backend.get_memory_stats()
+    _print_memory(mem_init, "after init")
+
+    rank_losses: dict[int, list[float]] = {}
+    for rank_val in (4, 8, 16):
+        lora_id = f"lora_r{rank_val}"
+        await backend.create_adapter(lora_id, types.LoraConfig(rank=rank_val, seed=42))
+
+        mem_after = await backend.get_memory_stats()
+        _print_memory(mem_after, f"after create {lora_id}")
+
+        losses: list[float] = []
+        for step in range(4):
+            loss = await _train_step(backend, data, lora_id)
+            losses.append(loss)
+            print(f"  [{lora_id}] step {step}  loss={loss:.4f}", flush=True)
+
+        rank_losses[rank_val] = losses
+
+        for i in range(1, len(losses)):
+            assert losses[i] < losses[i - 1], (
+                f"{lora_id}: loss did not decrease at step {i}: "
+                f"{losses[i]:.4f} >= {losses[i - 1]:.4f}"
+            )
+
+    mem_end = await backend.get_memory_stats()
+    _print_memory(mem_end, "end of multi-adapter test")
+
+    for s in mem_end:
+        assert s["allocated_mb"] > 0, "Expected non-zero GPU allocation"
+        assert s["reserved_mb"] < 50000, "Unexpected memory explosion"
+
+
+# ===================================================================
+# Test 2 — Training-state preservation across adapter switches
+# ===================================================================
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_training_state_preservation(fsdp_ray_cluster):
+    """Verify that weights and optimizer state survive adapter switches.
+
+    1. Train adapter_x for 3 steps → get eval loss
+    2. Switch to adapter_y → train 2 steps
+    3. Switch back to adapter_x → get eval loss (should match step 1 end)
+    4. Continue training adapter_x for 3 more steps → loss keeps decreasing
+    """
+    config = _make_config(MODEL_A_PATH)
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_A_PATH, name="default")
+
+    await backend.create_adapter("adapter_x", types.LoraConfig(rank=8, seed=42))
+    await backend.create_adapter("adapter_y", types.LoraConfig(rank=4, seed=99))
+
+    # --- Phase 1: train adapter_x for 3 steps ---
+    losses_x_phase1: list[float] = []
+    for step in range(3):
+        loss = await _train_step(backend, data, "adapter_x")
+        losses_x_phase1.append(loss)
+        print(f"  [phase1] adapter_x step {step}  loss={loss:.4f}", flush=True)
+
+    eval_loss_before_switch = await _forward_only(backend, data, "adapter_x")
+    print(
+        f"  [phase1] adapter_x eval loss before switch = {eval_loss_before_switch:.4f}",
+        flush=True,
+    )
+
+    # --- Phase 2: switch to adapter_y, train 2 steps ---
+    for step in range(2):
+        loss = await _train_step(backend, data, "adapter_y")
+        print(f"  [phase2] adapter_y step {step}  loss={loss:.4f}", flush=True)
+
+    # --- Phase 3: switch back to adapter_x ---
+    eval_loss_after_switch = await _forward_only(backend, data, "adapter_x")
+    print(
+        f"  [phase3] adapter_x eval loss after switch  = {eval_loss_after_switch:.4f}",
+        flush=True,
+    )
+
+    assert abs(eval_loss_after_switch - eval_loss_before_switch) < 0.01, (
+        f"adapter_x weights changed during adapter_y training: "
+        f"{eval_loss_before_switch:.4f} → {eval_loss_after_switch:.4f}"
+    )
+
+    # --- Phase 4: continue training adapter_x ---
+    losses_x_phase2: list[float] = []
+    for step in range(3):
+        loss = await _train_step(backend, data, "adapter_x")
+        losses_x_phase2.append(loss)
+        print(f"  [phase4] adapter_x step {step + 3}  loss={loss:.4f}", flush=True)
+
+    assert losses_x_phase2[0] < losses_x_phase1[-1] + 0.1, (
+        "adapter_x should continue improving from where it left off"
+    )
+    all_x_losses = losses_x_phase1 + losses_x_phase2
+    for i in range(1, len(all_x_losses)):
+        assert all_x_losses[i] < all_x_losses[i - 1] + 0.05, (
+            f"adapter_x non-monotonic at step {i}: "
+            f"{all_x_losses[i]:.4f} >= {all_x_losses[i - 1]:.4f}"
+        )
+
+    mem = await backend.get_memory_stats()
+    _print_memory(mem, "end of preservation test")
+
+
+# ===================================================================
+# Test 3 — Sequential training on two base models
+# ===================================================================
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_multi_model_sequential(fsdp_ray_cluster):
+    """Train on model A, shut down, train on model B.
+    Save checkpoints from both; verify checkpoint files exist.
+    """
+    if MODEL_B_PATH is None:
+        pytest.skip("FSDP_TEST_MODEL_B not set — need two distinct models")
+
+    ckpt_paths: dict[str, Path] = {}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # --- Model A ---
+        print("\n=== Model A: training ===", flush=True)
+        cfg_a = _make_config(MODEL_A_PATH)
+        backend_a = FSDPTrainingBackend(cfg_a)
+        await backend_a.async_init()
+        data_a = _construct_data(MODEL_A_PATH, name="default")
+
+        await backend_a.create_adapter("lora_a", types.LoraConfig(rank=8, seed=42))
+        losses_a: list[float] = []
+        for step in range(4):
+            loss = await _train_step(backend_a, data_a, "lora_a")
+            losses_a.append(loss)
+            print(f"  [model_a] step {step}  loss={loss:.4f}", flush=True)
+
+        ckpt_a = CheckpointRecord(
+            checkpoint_id="lora_a",
+            owner_name="default",
+            checkpoint_type="training",
+            path=tmpdir / "ckpt_model_a",
+            training_run_id="test_multi_model",
+            size_bytes=0,
+        )
+        await backend_a.save_state(lora_id="lora_a", checkpoint_record=ckpt_a, optimizer=True)
+        ckpt_paths["model_a"] = ckpt_a.adapter_path
+
+        mem_a = await backend_a.get_memory_stats()
+        _print_memory(mem_a, "model_a before shutdown")
+        backend_a.shutdown()
+        print("  [model_a] shut down", flush=True)
+
+        clear_ray_state()
+        time.sleep(5)
+        ray.init(ignore_reinit_error=True)
+
+        # --- Model B ---
+        print("\n=== Model B: training ===", flush=True)
+        cfg_b = _make_config(MODEL_B_PATH)
+        backend_b = FSDPTrainingBackend(cfg_b)
+        await backend_b.async_init()
+        data_b = _construct_data(MODEL_B_PATH, name="default")
+
+        await backend_b.create_adapter("lora_b", types.LoraConfig(rank=8, seed=42))
+        losses_b: list[float] = []
+        for step in range(4):
+            loss = await _train_step(backend_b, data_b, "lora_b")
+            losses_b.append(loss)
+            print(f"  [model_b] step {step}  loss={loss:.4f}", flush=True)
+
+        ckpt_b = CheckpointRecord(
+            checkpoint_id="lora_b",
+            owner_name="default",
+            checkpoint_type="training",
+            path=tmpdir / "ckpt_model_b",
+            training_run_id="test_multi_model",
+            size_bytes=0,
+        )
+        await backend_b.save_state(lora_id="lora_b", checkpoint_record=ckpt_b, optimizer=True)
+        ckpt_paths["model_b"] = ckpt_b.adapter_path
+
+        mem_b = await backend_b.get_memory_stats()
+        _print_memory(mem_b, "model_b before shutdown")
+        backend_b.shutdown()
+        print("  [model_b] shut down", flush=True)
+
+        # --- Verify losses decreased ---
+        for i in range(1, len(losses_a)):
+            assert losses_a[i] < losses_a[i - 1], "model_a loss did not decrease"
+        for i in range(1, len(losses_b)):
+            assert losses_b[i] < losses_b[i - 1], "model_b loss did not decrease"
+
+        # --- Verify checkpoint files ---
+        for tag, adapter_path in ckpt_paths.items():
+            assert adapter_path.exists(), f"{tag} adapter_path missing"
+            files = list(adapter_path.iterdir())
+            assert len(files) > 0, f"{tag} adapter_path is empty"
+            print(f"  [{tag}] checkpoint files: {[f.name for f in files]}", flush=True)
+
+
+# ===================================================================
+# Test 4 — Deploy trained adapter to vLLM inference
+# ===================================================================
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_inference_deployment(fsdp_ray_cluster):
+    """Train a LoRA adapter with FSDP2, save it, load into vLLM, and sample."""
+    try:
+        from tuft.backends.sampling_backend import VLLMSamplingBackend
+    except ImportError:
+        pytest.skip("VLLMSamplingBackend not available (missing vllm/trinity)")
+        return
+    model_path = MODEL_A_PATH
+    assert model_path is not None
+    config = _make_config(model_path)
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(model_path, name="default")
+
+    await backend.create_adapter("lora_infer", types.LoraConfig(rank=8, seed=42))
+
+    print("\n=== Training for inference deployment ===", flush=True)
+    for step in range(40):
+        loss = await _train_step(backend, data, "lora_infer")
+        if step % 10 == 0:
+            print(f"  step {step}  loss={loss:.4f}", flush=True)
+
+    mem_train = await backend.get_memory_stats()
+    _print_memory(mem_train, "after training")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ckpt = CheckpointRecord(
+            checkpoint_id="lora_infer",
+            owner_name="default",
+            checkpoint_type="training",
+            path=Path(tmpdir) / "lora_infer",
+            training_run_id="test_inference",
+            size_bytes=0,
+        )
+        await backend.save_state(lora_id="lora_infer", checkpoint_record=ckpt, optimizer=False)
+        backend.shutdown()
+        time.sleep(3)
+
+        print("\n=== Deploying to vLLM ===", flush=True)
+        sampling_config = ModelConfig(
+            model_name=model_path.name,
+            model_path=model_path,
+            max_model_len=2048,
+            tensor_parallel_size=1,
+            colocate=False,
+            max_lora_rank=16,
+        )
+        sampling_backend = VLLMSamplingBackend(sampling_config)
+        await sampling_backend.async_init()
+
+        await sampling_backend.add_adapter("lora_infer", ckpt.adapter_path)
+        print("  adapter loaded into vLLM", flush=True)
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
+        correct = 0
+        total = len(PIG_LATIN_EXAMPLES)
+        for prompt_text, example in zip(TEST_PROMPTS, PIG_LATIN_EXAMPLES, strict=True):
+            prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=True)
+            sample_res = await sampling_backend.sample(
+                prompt=types.ModelInput.from_ints(prompt_tokens),
+                num_samples=1,
+                sampling_params=types.SamplingParams(
+                    max_tokens=16, temperature=0.1, top_p=1.0, stop=["\n"]
+                ),
+                lora_id="lora_infer",
+            )
+            assert sample_res.sequences and sample_res.sequences[0].tokens
+            output_text = tokenizer.decode(sample_res.sequences[0].tokens, skip_special_tokens=True)
+            expected = _normalize_text(example["output"])
+            got = _normalize_text(output_text)
+            match = got == expected
+            correct += int(match)
+            print(
+                f"  prompt='{prompt_text.strip()}'  "
+                f"expected='{expected}'  got='{got}'  {'OK' if match else 'MISMATCH'}",
+                flush=True,
+            )
+
+        print(f"\n  inference accuracy: {correct}/{total}", flush=True)
+        assert correct >= total - 1, (
+            f"Only {correct}/{total} samples matched Pig Latin after FSDP training. "
+            f"At least {total - 1}/{total} expected."
+        )
+
+
+# ===================================================================
+# Test 5 — GPU memory lifecycle
+# ===================================================================
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_gpu_memory_lifecycle(fsdp_ray_cluster):
+    """Track GPU memory at each lifecycle stage — init, adapter creation,
+    forward, backward, optim, and after adapter removal.
+    Verify no memory explosion or leaks.
+    """
+    config = _make_config(MODEL_A_PATH)
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_A_PATH, name="default")
+
+    mem_init = await backend.get_memory_stats()
+    _print_memory(mem_init, "after model init")
+
+    await backend.create_adapter("mem_lora", types.LoraConfig(rank=8, seed=42))
+    mem_adapter = await backend.get_memory_stats()
+    _print_memory(mem_adapter, "after create_adapter")
+
+    await backend.forward(
+        data=data,
+        lora_id="mem_lora",
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=False,
+    )
+    mem_fwd = await backend.get_memory_stats()
+    _print_memory(mem_fwd, "after forward (no backward)")
+
+    await backend.forward(
+        data=data,
+        lora_id="mem_lora",
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=True,
+    )
+    mem_bwd = await backend.get_memory_stats()
+    _print_memory(mem_bwd, "after forward+backward")
+
+    await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="mem_lora")
+    mem_optim = await backend.get_memory_stats()
+    _print_memory(mem_optim, "after optim_step")
+
+    await backend.remove_adapter("mem_lora")
+    mem_removed = await backend.get_memory_stats()
+    _print_memory(mem_removed, "after remove_adapter")
+
+    for r0_init, r0_removed in zip(mem_init, mem_removed, strict=True):
+        delta = r0_removed["allocated_mb"] - r0_init["allocated_mb"]
+        assert delta < 500, f"rank {r0_init['rank']}: {delta:.0f}MB leaked after remove_adapter"
+
+    for s in mem_bwd:
+        assert s["allocated_mb"] < 30000, (
+            f"rank {s['rank']}: unexpectedly high memory "
+            f"after forward+backward: {s['allocated_mb']:.0f}MB"
+        )

--- a/tests/test_fsdp_e2e.py
+++ b/tests/test_fsdp_e2e.py
@@ -25,6 +25,10 @@ Usage:
 
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("torch", reason="FSDP tests require PyTorch")
+
 import os
 import tempfile
 import threading
@@ -34,7 +38,6 @@ from typing import Any, List
 
 import httpx
 import numpy as np
-import pytest
 import ray
 import tinker.types as types
 import uvicorn

--- a/tests/test_fsdp_e2e.py
+++ b/tests/test_fsdp_e2e.py
@@ -1,0 +1,1061 @@
+"""FSDP2 End-to-End Integration Tests.
+
+Covers the FSDP2 multi-GPU training through both:
+  A) Full server API  (ServiceClient -> HTTP -> TrainingController -> FSDPTrainingBackend)
+  B) Direct backend API  (FSDPTrainingBackend -> FSDPWorkerGroup -> FSDPTrainingWorker)
+
+Scenarios tested:
+  1. Mid-training adapter creation with different ranks  (server)
+  2. Full pipeline: interleaved training -> save -> inference  (server)
+  3. Dynamic adapter lifecycle: create / train / remove / reload  (backend)
+  4. Checkpoint + resume with optimizer state  (backend)
+  5. Rapid adapter switching under stress  (backend)
+  6. Adapter churn memory stability  (backend)
+  7. Forward / backward / optim decoupled operations  (backend)
+
+Requires:
+    - ``--gpu`` pytest flag
+    - ``TUFT_TEST_MODEL`` environment variable pointing to a HuggingFace model
+    - At least 2 GPUs available (FSDP_TEST_GPUS, default 2)
+
+Usage:
+    TUFT_TEST_MODEL=/path/to/model \\
+    pytest -xvs tests/test_fsdp_e2e.py --gpu -m gpu
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, List
+
+import httpx
+import numpy as np
+import pytest
+import ray
+import tinker.types as types
+import uvicorn
+from tinker.lib.public_interfaces.service_client import ServiceClient
+from transformers import AutoTokenizer
+
+from tuft.backends.fsdp_training_backend import FSDPTrainingBackend
+from tuft.checkpoints import CheckpointRecord
+from tuft.config import AppConfig, ModelConfig
+from tuft.server import create_root_app
+
+from .helpers import (
+    PIG_LATIN_EXAMPLES,
+    PIG_LATIN_EXAMPLES_EXTENDED,
+    REVERSE_EXAMPLES,
+    REVERSE_PROMPTS,
+    TEST_PROMPTS,
+    _create_reverse_training_data,
+    _create_training_data,
+    _find_free_port,
+    _log,
+    _normalize_text,
+    clear_ray_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model paths
+# ---------------------------------------------------------------------------
+MODEL_PATH = Path(os.environ["TUFT_TEST_MODEL"]) if "TUFT_TEST_MODEL" in os.environ else None
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+NUM_FSDP_GPUS = max(2, int(os.environ.get("FSDP_TEST_GPUS", "2")))
+
+
+def _skip_if_no_model():
+    if MODEL_PATH is None:
+        pytest.skip("TUFT_TEST_MODEL not set")
+
+
+# ---------------------------------------------------------------------------
+# Reusable helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(model_path: Path | None = MODEL_PATH, **overrides) -> ModelConfig:
+    assert model_path is not None, "TUFT_TEST_MODEL must be set"
+    defaults: dict[str, Any] = dict(
+        model_name=MODEL_NAME,
+        model_path=model_path,
+        max_model_len=2048,
+        tensor_parallel_size=1,
+        training_backend="fsdp",
+        num_gpus_per_node=NUM_FSDP_GPUS,
+        num_nodes=1,
+        max_lora_rank=32,
+    )
+    defaults.update(overrides)
+    return ModelConfig(**defaults)
+
+
+def _construct_data(model_path: Path | None, name: str = "extended") -> List[types.Datum]:
+    assert model_path is not None, "TUFT_TEST_MODEL must be set"
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    examples = PIG_LATIN_EXAMPLES_EXTENDED if name == "extended" else PIG_LATIN_EXAMPLES
+    data: list[types.Datum] = []
+    for example in examples:
+        prompt = f"English: {example['input']}\nPig Latin:"
+        prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+        completion_tokens = tokenizer.encode(f" {example['output']}\n\n", add_special_tokens=False)
+        tokens = prompt_tokens + completion_tokens
+        weights = [0] * len(prompt_tokens) + [1] * len(completion_tokens)
+        input_tokens = tokens[:-1]
+        target_tokens = tokens[1:]
+        weights = weights[1:]
+        data.append(
+            types.Datum(
+                model_input=types.ModelInput.from_ints(tokens=input_tokens),
+                loss_fn_inputs=dict(
+                    weights=types.TensorData(data=weights, dtype="float32"),
+                    target_tokens=types.TensorData(data=target_tokens, dtype="int64"),
+                ),
+            )
+        )
+    return data
+
+
+def _compute_loss(output: types.ForwardBackwardOutput, data) -> float:
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+    logprobs = np.concatenate([o["logprobs"].tolist() for o in output.loss_fn_outputs])
+    return float(-np.dot(logprobs, weights) / weights.sum())
+
+
+async def _train_step(
+    backend: FSDPTrainingBackend,
+    data,
+    lora_id: str,
+    lr: float = 1e-4,
+) -> float:
+    output = await backend.forward(
+        data=data,
+        lora_id=lora_id,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=True,
+    )
+    await backend.optim_step(types.AdamParams(learning_rate=lr), lora_id=lora_id)
+    return _compute_loss(output, data)
+
+
+async def _forward_only(
+    backend: FSDPTrainingBackend,
+    data,
+    lora_id: str,
+) -> float:
+    output = await backend.forward(
+        data=data,
+        lora_id=lora_id,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=False,
+    )
+    return _compute_loss(output, data)
+
+
+def _print_memory(stats: list[dict], tag: str) -> None:
+    for s in stats:
+        print(
+            f"  [{tag}] rank {s['rank']}  "
+            f"alloc={s['allocated_mb']:.0f}MB  "
+            f"reserved={s['reserved_mb']:.0f}MB  "
+            f"peak={s['max_allocated_mb']:.0f}MB",
+            flush=True,
+        )
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture(scope="function")
+def fsdp_ray_cluster(request):
+    """Function-scoped Ray cluster for backend-level tests."""
+    if not request.config.getoption("--gpu"):
+        yield
+        return
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if torch.cuda.device_count() < NUM_FSDP_GPUS:
+        pytest.skip(
+            f"Need at least {NUM_FSDP_GPUS} GPUs for FSDP, found {torch.cuda.device_count()}"
+        )
+    _skip_if_no_model()
+    clear_ray_state()
+    ray.init(
+        ignore_reinit_error=True,
+        runtime_env={"env_vars": {"TRANSFORMERS_NO_TORCHVISION": "1"}},
+    )
+    yield
+    clear_ray_state()
+
+
+@pytest.fixture(scope="function")
+def fsdp_server(request, tmp_path):
+    """Function-scoped server fixture with FSDP training backend.
+
+    Starts a full TuFT server with a single FSDP-backed model,
+    yields the base URL, and tears everything down after the test.
+    """
+    if not request.config.getoption("--gpu"):
+        yield None, None
+        return
+
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if torch.cuda.device_count() < NUM_FSDP_GPUS:
+        pytest.skip(
+            f"Need at least {NUM_FSDP_GPUS} GPUs for FSDP, found {torch.cuda.device_count()}"
+        )
+    _skip_if_no_model()
+    assert MODEL_PATH is not None
+    if not MODEL_PATH.exists():
+        pytest.skip(f"Model not found at {MODEL_PATH}")
+
+    clear_ray_state()
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29500")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("RANK", "0")
+
+    _log("Starting Ray for FSDP server test...")
+    ray.init(
+        ignore_reinit_error=True,
+        runtime_env={"env_vars": {"TRANSFORMERS_NO_TORCHVISION": "1"}},
+    )
+
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    config = AppConfig(checkpoint_dir=checkpoint_dir)
+    config.supported_models = [
+        ModelConfig(
+            model_name=MODEL_NAME,
+            model_path=MODEL_PATH,
+            max_model_len=2048,
+            tensor_parallel_size=1,
+            training_backend="fsdp",
+            num_gpus_per_node=NUM_FSDP_GPUS,
+            num_nodes=1,
+            max_lora_rank=32,
+        ),
+    ]
+    config.authorized_users = {"tml-fsdp-test-key": "default"}
+
+    _log("Creating FastAPI app with FSDP backend...")
+    app = create_root_app(config)
+    port = _find_free_port()
+    _log(f"Starting FSDP server on port {port}...")
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    client = httpx.Client()
+    healthy = False
+    for attempt in range(1, 181):
+        try:
+            response = client.get(f"{base_url}/api/v1/healthz", timeout=1)
+            response.raise_for_status()
+            healthy = True
+            break
+        except httpx.HTTPError:
+            time.sleep(2)
+        if attempt % 10 == 0:
+            _log(f"Waiting for FSDP server healthz... attempt {attempt}/180")
+    if not healthy:
+        server.should_exit = True
+        thread.join(timeout=10)
+        client.close()
+        clear_ray_state()
+        raise RuntimeError("FSDP server failed to start within 6 minutes")
+    _log("FSDP server is healthy")
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+    yield base_url, tokenizer
+
+    _log("Tearing down FSDP server...")
+    server.should_exit = True
+    thread.join(timeout=10)
+    client.close()
+    clear_ray_state()
+
+
+# ===================================================================
+# SECTION A — Server Integration Tests
+# ===================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_fsdp_e2e_mid_training_new_adapter(fsdp_server) -> None:
+    """Create new adapters DURING an ongoing training session.
+
+    Flow:
+      1. Create adapter_a (rank=8), train 5 epochs solo
+      2. Create adapter_b (rank=4)  ← mid-training
+      3. Train a + b interleaved for 5 epochs
+      4. Create adapter_c (rank=16)  ← mid-training again
+      5. Train a + b + c interleaved for 3 epochs
+      6. Save all three for sampler
+      7. Deploy each to inference and verify output
+    """
+    base_url, tokenizer = fsdp_server
+    if base_url is None:
+        pytest.skip("Server fixture not available")
+
+    service_client = ServiceClient(
+        api_key="tml-fsdp-test-key",  # pragma: allowlist secret
+        base_url=base_url,
+        timeout=300,
+    )
+    try:
+        caps = service_client.get_server_capabilities()
+        assert caps.supported_models, "no supported models"
+        base_model = caps.supported_models[0].model_name
+        _log(f"Base model: {base_model}")
+
+        train_data = _create_training_data(tokenizer)
+
+        # --- Phase 1: solo training of adapter_a ---
+        _log("Phase 1: Creating adapter_a (rank=8) ...")
+        client_a = service_client.create_lora_training_client(base_model=base_model, rank=8)
+        for epoch in range(1, 6):
+            client_a.forward_backward(train_data, "cross_entropy").result(timeout=180)
+            client_a.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            _log(f"  [Phase 1] adapter_a epoch {epoch}/5")
+
+        # --- Phase 2: create adapter_b mid-training ---
+        _log("Phase 2: Creating adapter_b (rank=4) mid-training ...")
+        client_b = service_client.create_lora_training_client(base_model=base_model, rank=4)
+        for epoch in range(1, 6):
+            client_a.forward_backward(train_data, "cross_entropy").result(timeout=180)
+            client_a.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            client_b.forward_backward(train_data, "cross_entropy").result(timeout=180)
+            client_b.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            _log(f"  [Phase 2] a+b epoch {epoch}/5")
+
+        # --- Phase 3: create adapter_c mid-training ---
+        _log("Phase 3: Creating adapter_c (rank=16) mid-training ...")
+        client_c = service_client.create_lora_training_client(base_model=base_model, rank=16)
+        for epoch in range(1, 4):
+            for c in [client_a, client_b, client_c]:
+                c.forward_backward(train_data, "cross_entropy").result(timeout=180)
+                c.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            _log(f"  [Phase 3] a+b+c epoch {epoch}/3")
+
+        # --- Save all for sampler ---
+        _log("Saving all adapters for sampler ...")
+        sampling_clients = []
+        for _i, (label, client) in enumerate([("a", client_a), ("b", client_b), ("c", client_c)]):
+            resp = client.save_weights_for_sampler(f"fsdp-e2e-{label}").result(timeout=120)
+            assert resp.path.startswith("tinker://"), f"Bad sampler path: {resp.path}"
+            _log(f"  adapter_{label} saved: {resp.path}")
+            sampling_clients.append(service_client.create_sampling_client(model_path=resp.path))
+
+        # --- Inference verification ---
+        _log("Verifying inference outputs ...")
+        for sc_idx, sampling_client in enumerate(sampling_clients):
+            correct = 0
+            for prompt_text, example in zip(TEST_PROMPTS, PIG_LATIN_EXAMPLES, strict=True):
+                prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=True)
+                sample_res = sampling_client.sample(
+                    prompt=types.ModelInput.from_ints(prompt_tokens),
+                    num_samples=1,
+                    sampling_params=types.SamplingParams(
+                        max_tokens=16,
+                        temperature=0.1,
+                        top_p=1.0,
+                        stop=["\n"],
+                    ),
+                ).result(timeout=60)
+                assert sample_res.sequences and sample_res.sequences[0].tokens
+                output_text = tokenizer.decode(
+                    sample_res.sequences[0].tokens, skip_special_tokens=True
+                )
+                expected = _normalize_text(example["output"])
+                got = _normalize_text(output_text)
+                if got == expected:
+                    correct += 1
+                _log(
+                    f"  adapter[{sc_idx}] '{prompt_text.strip()}'  "
+                    f"exp='{expected}' got='{got}' {'OK' if got == expected else 'MISS'}"
+                )
+            _log(f"  adapter[{sc_idx}] accuracy: {correct}/{len(PIG_LATIN_EXAMPLES)}")
+
+        _log("test_fsdp_e2e_mid_training_new_adapter PASSED")
+    finally:
+        service_client.holder.close()
+
+
+@pytest.mark.integration
+@pytest.mark.gpu
+def test_fsdp_e2e_interleaved_task_isolation(fsdp_server) -> None:
+    """Two adapters learn DIFFERENT tasks through interleaved FSDP training.
+
+    Adapter A learns Pig Latin; Adapter B learns Reverse Words.
+    Validates that FSDP multi-tenant training keeps adapters isolated.
+    """
+    base_url, tokenizer = fsdp_server
+    if base_url is None:
+        pytest.skip("Server fixture not available")
+
+    service_client = ServiceClient(
+        api_key="tml-fsdp-test-key",  # pragma: allowlist secret
+        base_url=base_url,
+        timeout=300,
+    )
+    try:
+        caps = service_client.get_server_capabilities()
+        base_model = caps.supported_models[0].model_name
+
+        pig_data = _create_training_data(tokenizer)
+        rev_data = _create_reverse_training_data(tokenizer)
+
+        _log("Creating adapter_pig (rank=8) and adapter_rev (rank=8) ...")
+        client_pig = service_client.create_lora_training_client(base_model=base_model, rank=8)
+        client_rev = service_client.create_lora_training_client(base_model=base_model, rank=8)
+
+        _log("Interleaved training (20 epochs) ...")
+        for epoch in range(1, 21):
+            client_pig.forward_backward(pig_data, "cross_entropy").result(timeout=180)
+            client_pig.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            client_rev.forward_backward(rev_data, "cross_entropy").result(timeout=180)
+            client_rev.optim_step(types.AdamParams(learning_rate=1e-4)).result(timeout=120)
+            if epoch % 5 == 0:
+                _log(f"  interleaved epoch {epoch}/20")
+
+        # Save and deploy
+        sampler_pig = client_pig.save_weights_for_sampler("pig-iso").result(timeout=120)
+        sampler_rev = client_rev.save_weights_for_sampler("rev-iso").result(timeout=120)
+        sc_pig = service_client.create_sampling_client(model_path=sampler_pig.path)
+        sc_rev = service_client.create_sampling_client(model_path=sampler_rev.path)
+
+        # Validate Pig Latin adapter
+        _log("Validating Pig Latin adapter ...")
+        pig_correct = 0
+        for prompt_text, example in zip(TEST_PROMPTS, PIG_LATIN_EXAMPLES, strict=True):
+            tokens = tokenizer.encode(prompt_text, add_special_tokens=True)
+            res = sc_pig.sample(
+                prompt=types.ModelInput.from_ints(tokens),
+                num_samples=1,
+                sampling_params=types.SamplingParams(
+                    max_tokens=16,
+                    temperature=0.1,
+                    top_p=1.0,
+                    stop=["\n"],
+                ),
+            ).result(timeout=60)
+            output = _normalize_text(
+                tokenizer.decode(res.sequences[0].tokens, skip_special_tokens=True)
+            )
+            expected = _normalize_text(example["output"])
+            match = output == expected
+            pig_correct += int(match)
+            _log(
+                f"  pig: '{prompt_text.strip()}'  exp='{expected}' got='{output}' "
+                f"{'OK' if match else 'MISS'}"
+            )
+        _log(f"  Pig Latin accuracy: {pig_correct}/{len(PIG_LATIN_EXAMPLES)}")
+        assert pig_correct >= len(PIG_LATIN_EXAMPLES) - 1, (
+            f"Pig Latin adapter too inaccurate: {pig_correct}/{len(PIG_LATIN_EXAMPLES)}"
+        )
+
+        # Validate Reverse adapter
+        _log("Validating Reverse adapter ...")
+        rev_correct = 0
+        for prompt_text, example in zip(REVERSE_PROMPTS, REVERSE_EXAMPLES, strict=True):
+            tokens = tokenizer.encode(prompt_text, add_special_tokens=True)
+            res = sc_rev.sample(
+                prompt=types.ModelInput.from_ints(tokens),
+                num_samples=1,
+                sampling_params=types.SamplingParams(
+                    max_tokens=32,
+                    temperature=0.0,
+                    top_p=1.0,
+                    stop=["\n"],
+                ),
+            ).result(timeout=60)
+            output = _normalize_text(
+                tokenizer.decode(res.sequences[0].tokens, skip_special_tokens=True)
+            )
+            expected = _normalize_text(example["output"])
+            match = output == expected
+            rev_correct += int(match)
+            _log(
+                f"  rev: '{prompt_text.strip()}'  exp='{expected}' got='{output}' "
+                f"{'OK' if match else 'MISS'}"
+            )
+        _log(f"  Reverse accuracy: {rev_correct}/{len(REVERSE_EXAMPLES)}")
+        assert rev_correct >= len(REVERSE_EXAMPLES) - 2, (
+            f"Reverse adapter too inaccurate: {rev_correct}/{len(REVERSE_EXAMPLES)}"
+        )
+
+        # Cross-check isolation: Pig Latin adapter should NOT produce reversed words
+        cross_prompt = "Reverse each word.\nEnglish: hello world\nReversed:"
+        cross_tokens = tokenizer.encode(cross_prompt, add_special_tokens=True)
+        cross_res = sc_pig.sample(
+            prompt=types.ModelInput.from_ints(cross_tokens),
+            num_samples=1,
+            sampling_params=types.SamplingParams(
+                max_tokens=32,
+                temperature=0.0,
+                top_p=1.0,
+                stop=["\n"],
+            ),
+        ).result(timeout=60)
+        cross_out = _normalize_text(
+            tokenizer.decode(cross_res.sequences[0].tokens, skip_special_tokens=True)
+        )
+        _log(f"  Cross-check: Pig Latin adapter on reverse prompt → '{cross_out}'")
+        assert cross_out != _normalize_text("olleh dlrow"), (
+            "Pig Latin adapter incorrectly learned reverse task"
+        )
+
+        _log("test_fsdp_e2e_interleaved_task_isolation PASSED")
+    finally:
+        service_client.holder.close()
+
+
+# ===================================================================
+# SECTION B — Backend Edge-Case Tests
+# ===================================================================
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_dynamic_adapter_lifecycle(fsdp_ray_cluster) -> None:
+    """Create / train / remove / create new adapters dynamically.
+
+    Verifies that:
+      - Removing an adapter frees its resources
+      - Remaining adapters keep working
+      - New adapters can be created and trained after removal
+      - GPU memory is stable
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        mem_init = await backend.get_memory_stats()
+        _print_memory(mem_init, "init")
+
+        # Create adapter_1 (rank=8), train 3 steps
+        _log("Creating adapter_1 (rank=8) ...")
+        await backend.create_adapter("adapter_1", types.LoraConfig(rank=8, seed=42))
+        losses_1: list[float] = []
+        for step in range(3):
+            loss = await _train_step(backend, data, "adapter_1")
+            losses_1.append(loss)
+            _log(f"  adapter_1 step {step} loss={loss:.4f}")
+
+        # Create adapter_2 (rank=16), train 2 steps
+        _log("Creating adapter_2 (rank=16) ...")
+        await backend.create_adapter("adapter_2", types.LoraConfig(rank=16, seed=99))
+        losses_2: list[float] = []
+        for step in range(2):
+            loss = await _train_step(backend, data, "adapter_2")
+            losses_2.append(loss)
+            _log(f"  adapter_2 step {step} loss={loss:.4f}")
+
+        mem_two_adapters = await backend.get_memory_stats()
+        _print_memory(mem_two_adapters, "two adapters active")
+
+        # Remove adapter_1
+        _log("Removing adapter_1 ...")
+        await backend.remove_adapter("adapter_1")
+
+        mem_after_remove = await backend.get_memory_stats()
+        _print_memory(mem_after_remove, "after removing adapter_1")
+
+        # adapter_2 should still work
+        loss = await _train_step(backend, data, "adapter_2")
+        _log(f"  adapter_2 after removal of adapter_1: loss={loss:.4f}")
+        assert loss < losses_2[-1] + 0.1, "adapter_2 broken after adapter_1 removal"
+
+        # Create adapter_3 (rank=4), train 3 steps
+        _log("Creating adapter_3 (rank=4) ...")
+        await backend.create_adapter("adapter_3", types.LoraConfig(rank=4, seed=77))
+        losses_3: list[float] = []
+        for step in range(3):
+            loss = await _train_step(backend, data, "adapter_3")
+            losses_3.append(loss)
+            _log(f"  adapter_3 step {step} loss={loss:.4f}")
+
+        mem_end = await backend.get_memory_stats()
+        _print_memory(mem_end, "end of lifecycle test")
+
+        # Verify losses decrease
+        for i in range(1, len(losses_1)):
+            assert losses_1[i] < losses_1[i - 1], "adapter_1 loss not decreasing"
+        for i in range(1, len(losses_3)):
+            assert losses_3[i] < losses_3[i - 1], "adapter_3 loss not decreasing"
+
+        for s in mem_end:
+            assert s["allocated_mb"] < 50000, "Memory explosion detected"
+
+        _log("test_fsdp_dynamic_adapter_lifecycle PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_checkpoint_resume_optimizer(fsdp_ray_cluster) -> None:
+    """Train, checkpoint with optimizer, remove, reload, resume training.
+
+    Validates that optimizer momentum is preserved across checkpoint/resume
+    so training continues smoothly from the saved state.
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        await backend.create_adapter("ckpt_adapter", types.LoraConfig(rank=8, seed=42))
+
+        # Train 5 steps
+        losses_before: list[float] = []
+        for step in range(5):
+            loss = await _train_step(backend, data, "ckpt_adapter")
+            losses_before.append(loss)
+            _log(f"  [before save] step {step} loss={loss:.4f}")
+
+        eval_loss_before = await _forward_only(backend, data, "ckpt_adapter")
+        _log(f"  eval loss before save = {eval_loss_before:.4f}")
+
+        # Save checkpoint with optimizer
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt = CheckpointRecord(
+                checkpoint_id="ckpt_adapter",
+                owner_name="default",
+                checkpoint_type="training",
+                path=Path(tmpdir) / "ckpt",
+                training_run_id="test_resume",
+                size_bytes=0,
+            )
+            await backend.save_state("ckpt_adapter", ckpt, optimizer=True)
+            _log("  checkpoint saved (with optimizer)")
+
+            # Remove the adapter
+            await backend.remove_adapter("ckpt_adapter")
+            _log("  adapter removed")
+
+            # Reload from checkpoint (same name so optimizer files match)
+            await backend.load_state("ckpt_adapter", ckpt, optimizer=True)
+            _log("  adapter reloaded as ckpt_adapter")
+
+            eval_loss_after_reload = await _forward_only(backend, data, "ckpt_adapter")
+            _log(f"  eval loss after reload = {eval_loss_after_reload:.4f}")
+            assert abs(eval_loss_after_reload - eval_loss_before) < 1.0, (
+                f"Eval loss diverged too much after checkpoint reload: "
+                f"{eval_loss_before:.4f} → {eval_loss_after_reload:.4f}"
+            )
+
+            # Continue training 5 more steps
+            losses_after: list[float] = []
+            for step in range(5):
+                loss = await _train_step(backend, data, "ckpt_adapter")
+                losses_after.append(loss)
+                _log(f"  [after reload] step {step} loss={loss:.4f}")
+
+            assert losses_after[0] < losses_before[-1] + 0.1, (
+                "Training did not resume smoothly from checkpoint"
+            )
+
+            all_losses = losses_before + losses_after
+            regression_count = sum(
+                1 for i in range(1, len(all_losses)) if all_losses[i] > all_losses[i - 1] + 0.05
+            )
+            assert regression_count <= 1, (
+                f"Too many loss regressions ({regression_count}) across checkpoint boundary"
+            )
+
+            # --- Cross-name load: verify optimizer file is found even with new name ---
+            _log("  Testing cross-name checkpoint load ...")
+            await backend.remove_adapter("ckpt_adapter")
+            await backend.load_state("ckpt_adapter_renamed", ckpt, optimizer=True)
+            loss_renamed = await _train_step(backend, data, "ckpt_adapter_renamed")
+            _log(f"  cross-name load: first step loss = {loss_renamed:.4f}")
+            assert loss_renamed < losses_before[-1] + 0.5, (
+                "Cross-name checkpoint load failed to resume training"
+            )
+
+        _log("test_fsdp_checkpoint_resume_optimizer PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_rapid_adapter_switching(fsdp_ray_cluster) -> None:
+    """Stress test: rapidly switch between 4 adapters of different ranks.
+
+    Each iteration does forward+backward on every adapter, then optim_step
+    for each. Verifies no deadlocks, correct loss decrease, and stable memory.
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        adapters = [
+            ("rapid_r4", 4),
+            ("rapid_r8", 8),
+            ("rapid_r16", 16),
+            ("rapid_r32", 32),
+        ]
+        for name, rank in adapters:
+            await backend.create_adapter(name, types.LoraConfig(rank=rank, seed=42))
+            _log(f"  created {name} (rank={rank})")
+
+        mem_created = await backend.get_memory_stats()
+        _print_memory(mem_created, "after creating 4 adapters")
+
+        adapter_losses: dict[str, list[float]] = {name: [] for name, _ in adapters}
+
+        for iteration in range(4):
+            _log(f"  --- rapid switching iteration {iteration} ---")
+            for name, _ in adapters:
+                output = await backend.forward(
+                    data=data,
+                    lora_id=name,
+                    loss_fn="cross_entropy",
+                    loss_fn_config=None,
+                    backward=True,
+                )
+                loss = _compute_loss(output, data)
+                adapter_losses[name].append(loss)
+                _log(f"    {name} fwd+bwd loss={loss:.4f}")
+
+            for name, _ in adapters:
+                await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id=name)
+
+        mem_end = await backend.get_memory_stats()
+        _print_memory(mem_end, "after rapid switching")
+
+        for name, _ in adapters:
+            losses = adapter_losses[name]
+            assert losses[-1] < losses[0], (
+                f"{name}: final loss {losses[-1]:.4f} >= initial loss {losses[0]:.4f}"
+            )
+            _log(f"  {name}: {losses[0]:.4f} → {losses[-1]:.4f}  OK")
+
+        for s in mem_end:
+            assert s["allocated_mb"] < 50000, f"Memory explosion on rank {s['rank']}"
+
+        _log("test_fsdp_rapid_adapter_switching PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_adapter_churn_memory_stability(fsdp_ray_cluster) -> None:
+    """Repeatedly create, train, and remove adapters to verify no memory leak.
+
+    Runs 3 rounds of create → train → remove with 2 adapters each round.
+    Checks that GPU allocated memory doesn't grow beyond a reasonable bound.
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        mem_baseline = await backend.get_memory_stats()
+        _print_memory(mem_baseline, "baseline")
+
+        round_peak_deltas: list[float] = []
+
+        for round_idx in range(3):
+            _log(f"  --- churn round {round_idx} ---")
+
+            names = [f"churn_r{round_idx}_a", f"churn_r{round_idx}_b"]
+            for name in names:
+                await backend.create_adapter(name, types.LoraConfig(rank=8, seed=round_idx * 10))
+
+            for _step in range(2):
+                for name in names:
+                    await _train_step(backend, data, name)
+
+            for name in names:
+                await backend.remove_adapter(name)
+
+            mem_after = await backend.get_memory_stats()
+            _print_memory(mem_after, f"round {round_idx} after cleanup")
+
+            delta = mem_after[0]["allocated_mb"] - mem_baseline[0]["allocated_mb"]
+            round_peak_deltas.append(delta)
+            _log(f"  round {round_idx} mem delta: {delta:.0f} MB")
+
+        if len(round_peak_deltas) >= 2:
+            growth = round_peak_deltas[-1] - round_peak_deltas[0]
+            _log(f"  memory growth across rounds: {growth:.0f} MB")
+            assert growth < 1000, (
+                f"Suspected memory leak: {growth:.0f} MB growth "
+                f"across {len(round_peak_deltas)} rounds"
+            )
+
+        _log("test_fsdp_adapter_churn_memory_stability PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_forward_backward_optim_separation(fsdp_ray_cluster) -> None:
+    """Test that forward, backward, and optim_step can be decoupled.
+
+    Validates the multi-tenant scenario where these operations
+    happen as independent RPC calls (not always in lockstep).
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        await backend.create_adapter("decouple", types.LoraConfig(rank=8, seed=42))
+
+        # Forward-only should not change weights
+        eval_before = await _forward_only(backend, data, "decouple")
+        eval_after_fwd = await _forward_only(backend, data, "decouple")
+        _log(f"  forward-only: {eval_before:.4f} → {eval_after_fwd:.4f}")
+        assert abs(eval_after_fwd - eval_before) < 1e-3, "Forward-only changed the model weights"
+
+        # Forward + backward (no optim) should NOT change weights
+        # but SHOULD accumulate gradients
+        await backend.forward(
+            data=data,
+            lora_id="decouple",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        eval_after_bwd = await _forward_only(backend, data, "decouple")
+        _log(f"  after backward (no optim): {eval_after_bwd:.4f}")
+        assert abs(eval_after_bwd - eval_before) < 1e-3, (
+            "Backward without optim_step changed the model weights"
+        )
+
+        # Multiple forward+backward calls accumulate gradients
+        await backend.forward(
+            data=data,
+            lora_id="decouple",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+
+        # Now optim_step should apply the accumulated gradients
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="decouple")
+        eval_after_optim = await _forward_only(backend, data, "decouple")
+        _log(f"  after optim_step: {eval_after_optim:.4f}")
+        assert eval_after_optim < eval_before, (
+            f"Optim step did not improve loss: {eval_before:.4f} → {eval_after_optim:.4f}"
+        )
+
+        # Interleave with a second adapter
+        await backend.create_adapter("decouple_b", types.LoraConfig(rank=4, seed=99))
+
+        eval_a_before = await _forward_only(backend, data, "decouple")
+        await backend.forward(
+            data=data,
+            lora_id="decouple_b",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="decouple_b")
+        eval_a_after = await _forward_only(backend, data, "decouple")
+        _log(f"  adapter_a after adapter_b optim: {eval_a_before:.4f} → {eval_a_after:.4f}")
+        assert abs(eval_a_after - eval_a_before) < 0.01, (
+            "Adapter A weights changed when only adapter B was updated"
+        )
+
+        _log("test_fsdp_forward_backward_optim_separation PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_multitenant_gradient_isolation(fsdp_ray_cluster) -> None:
+    """Verify multi-tenant gradient/optimizer isolation on the same base model.
+
+    Two adapters (different ranks) share one FSDP2-wrapped base model.
+
+    1. Accumulate gradients for A, switch to B, train B, switch back to A,
+       verify A's pending grads are intact (optim produces the same result
+       as no-switch training).
+    2. Verify optimizer states are independent: training A does not shift B.
+    3. Verify cross-rank parameter consistency via fingerprints.
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "default")
+
+    try:
+        # --- Setup: two adapters with different ranks on the same base model ---
+        await backend.create_adapter("iso_a", types.LoraConfig(rank=8, seed=42))
+        await backend.create_adapter("iso_b", types.LoraConfig(rank=16, seed=99))
+
+        # ---- Phase 1: gradient preservation across adapter switch ----
+        _log("Phase 1: gradient preservation across adapter switch")
+
+        # Train adapter_a for 3 steps without interruption (control)
+        eval_a_init = await _forward_only(backend, data, "iso_a")
+        _log(f"  iso_a initial eval loss = {eval_a_init:.4f}")
+        for _ in range(3):
+            await _train_step(backend, data, "iso_a")
+        eval_a_control = await _forward_only(backend, data, "iso_a")
+        _log(f"  iso_a after 3 uninterrupted steps = {eval_a_control:.4f}")
+
+        # Reset: remove and re-create iso_a
+        await backend.remove_adapter("iso_a")
+        await backend.create_adapter("iso_a", types.LoraConfig(rank=8, seed=42))
+
+        # Same 3 steps, but interrupt with iso_b training between each
+        for step in range(3):
+            await backend.forward(
+                data=data,
+                lora_id="iso_a",
+                loss_fn="cross_entropy",
+                loss_fn_config=None,
+                backward=True,
+            )
+            # Switch away: train iso_b for 2 steps
+            for _ in range(2):
+                await _train_step(backend, data, "iso_b")
+            # Switch back and complete iso_a's optim
+            await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="iso_a")
+            _log(f"  iso_a interrupted step {step} completed")
+
+        eval_a_interrupted = await _forward_only(backend, data, "iso_a")
+        _log(f"  iso_a after 3 interrupted steps = {eval_a_interrupted:.4f}")
+
+        # The interrupted training should still make progress
+        assert eval_a_interrupted < eval_a_init, (
+            f"iso_a did not improve with interrupted training: "
+            f"{eval_a_init:.4f} → {eval_a_interrupted:.4f}"
+        )
+
+        # ---- Phase 2: optimizer state independence ----
+        _log("Phase 2: optimizer state independence")
+
+        eval_b_before = await _forward_only(backend, data, "iso_b")
+        # Train only iso_a for 5 more steps
+        for _ in range(5):
+            await _train_step(backend, data, "iso_a")
+        eval_b_after = await _forward_only(backend, data, "iso_b")
+        _log(f"  iso_b before/after iso_a training: {eval_b_before:.4f} → {eval_b_after:.4f}")
+        assert abs(eval_b_after - eval_b_before) < 0.01, (
+            f"iso_b weights shifted when only iso_a was trained: "
+            f"delta={abs(eval_b_after - eval_b_before):.6f}"
+        )
+
+        # ---- Phase 3: cross-rank parameter consistency ----
+        _log("Phase 3: cross-rank parameter consistency")
+
+        fps_a = backend.worker_group.get_adapter_param_fingerprint_all("iso_a")
+        fps_b = backend.worker_group.get_adapter_param_fingerprint_all("iso_b")
+        for fp in fps_a:
+            _log(f"  iso_a rank {fp['rank']}: sum={fp['param_sum']:.6f}  count={fp['param_count']}")
+        for fp in fps_b:
+            _log(f"  iso_b rank {fp['rank']}: sum={fp['param_sum']:.6f}  count={fp['param_count']}")
+
+        if len(fps_a) >= 2:
+            assert abs(fps_a[0]["param_sum"] - fps_a[1]["param_sum"]) < 1e-2, (
+                f"iso_a params diverged across ranks: "
+                f"rank0={fps_a[0]['param_sum']:.6f}  "
+                f"rank1={fps_a[1]['param_sum']:.6f}"
+            )
+        if len(fps_b) >= 2:
+            assert abs(fps_b[0]["param_sum"] - fps_b[1]["param_sum"]) < 1e-2, (
+                f"iso_b params diverged across ranks: "
+                f"rank0={fps_b[0]['param_sum']:.6f}  "
+                f"rank1={fps_b[1]['param_sum']:.6f}"
+            )
+
+        # Adapters must have different params (different ranks and training)
+        assert fps_a[0]["param_count"] != fps_b[0]["param_count"], (
+            "Adapters have the same param count despite different ranks"
+        )
+
+        _log("test_fsdp_multitenant_gradient_isolation PASSED")
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_cross_rank_param_sync(fsdp_ray_cluster) -> None:
+    """Verify LoRA parameters stay identical across ranks after training.
+
+    This specifically tests the AllReduce gradient synchronisation added
+    in optim_step.  Without it, each rank would apply different gradients
+    (from different data shards) and parameters would diverge.
+    """
+    config = _make_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+    data = _construct_data(MODEL_PATH, "extended")
+
+    try:
+        await backend.create_adapter("sync_test", types.LoraConfig(rank=8, seed=42))
+
+        fp_init = backend.worker_group.get_adapter_param_fingerprint_all("sync_test")
+        _log("Initial fingerprints:")
+        for fp in fp_init:
+            _log(f"  rank {fp['rank']}: sum={fp['param_sum']:.6f}")
+
+        if len(fp_init) >= 2:
+            assert abs(fp_init[0]["param_sum"] - fp_init[1]["param_sum"]) < 1e-4, (
+                "Parameters diverged at initialisation"
+            )
+
+        for step in range(10):
+            await _train_step(backend, data, "sync_test")
+            if step % 3 == 2:
+                fps = backend.worker_group.get_adapter_param_fingerprint_all("sync_test")
+                sums = [fp["param_sum"] for fp in fps]
+                max_diff = max(sums) - min(sums) if len(sums) > 1 else 0.0
+                _log(f"  step {step}: sums={[f'{s:.6f}' for s in sums]}  max_diff={max_diff:.8f}")
+                if len(sums) >= 2:
+                    assert max_diff < 1e-2, (
+                        f"Parameters diverged across ranks at step {step}: max_diff={max_diff:.8f}"
+                    )
+
+        fp_final = backend.worker_group.get_adapter_param_fingerprint_all("sync_test")
+        _log("Final fingerprints:")
+        for fp in fp_final:
+            _log(f"  rank {fp['rank']}: sum={fp['param_sum']:.6f}")
+
+        if len(fp_final) >= 2:
+            final_diff = abs(fp_final[0]["param_sum"] - fp_final[1]["param_sum"])
+            assert final_diff < 1e-2, f"Final params diverged: diff={final_diff:.8f}"
+
+        assert fp_final[0]["param_sum"] != fp_init[0]["param_sum"], (
+            "Parameters did not change during training"
+        )
+
+        _log("test_fsdp_cross_rank_param_sync PASSED")
+    finally:
+        backend.shutdown()

--- a/tests/test_fsdp_training.py
+++ b/tests/test_fsdp_training.py
@@ -1,0 +1,342 @@
+"""Tests for FSDP2 multi-GPU training backend.
+
+Mirrors the structure of test_training_backend.py but exercises the
+FSDPTrainingBackend with multiple GPUs.
+
+Requires:
+    - ``--gpu`` pytest flag
+    - ``TUFT_TEST_MODEL`` environment variable pointing to a HuggingFace model
+    - At least 2 GPUs available (FSDP_TEST_GPUS, default 2)
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, List
+
+import numpy as np
+import pytest
+import ray
+import transformers
+from tinker import types
+
+from tuft.backends.fsdp_training_backend import FSDPTrainingBackend
+from tuft.checkpoints import CheckpointRecord
+from tuft.config import ModelConfig
+
+from .helpers import (
+    PIG_LATIN_EXAMPLES,
+    PIG_LATIN_EXAMPLES_EXTENDED,
+    clear_ray_state,
+)
+
+
+NUM_FSDP_GPUS = max(2, int(os.environ.get("FSDP_TEST_GPUS", "2")))
+MODEL_PATH = Path(os.environ["TUFT_TEST_MODEL"]) if "TUFT_TEST_MODEL" in os.environ else None
+
+
+def _skip_if_no_model():
+    if MODEL_PATH is None:
+        pytest.skip("TUFT_TEST_MODEL not set")
+
+
+@pytest.fixture(scope="function")
+def fsdp_ray_cluster(request):
+    if not request.config.getoption("--gpu"):
+        yield
+        return
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if torch.cuda.device_count() < NUM_FSDP_GPUS:
+        pytest.skip(
+            f"Need at least {NUM_FSDP_GPUS} GPUs for FSDP, found {torch.cuda.device_count()}"
+        )
+    _skip_if_no_model()
+    clear_ray_state()
+    ray.init(ignore_reinit_error=True)
+    yield
+    clear_ray_state()
+
+
+def _construct_data(name: str = "extended") -> List[types.Datum]:
+    assert MODEL_PATH is not None, "TUFT_TEST_MODEL must be set for FSDP tests."
+    tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_PATH)
+    examples = PIG_LATIN_EXAMPLES_EXTENDED if name == "extended" else PIG_LATIN_EXAMPLES
+    data = []
+    for example in examples:
+        prompt = f"English: {example['input']}\nPig Latin:"
+        prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+        prompt_weights = [0] * len(prompt_tokens)
+        completion_tokens = tokenizer.encode(f" {example['output']}\n\n", add_special_tokens=False)
+        completion_weights = [1] * len(completion_tokens)
+
+        tokens = prompt_tokens + completion_tokens
+        weights = prompt_weights + completion_weights
+        input_tokens = tokens[:-1]
+        target_tokens = tokens[1:]
+        weights = weights[1:]
+
+        data.append(
+            types.Datum(
+                model_input=types.ModelInput.from_ints(tokens=input_tokens),
+                loss_fn_inputs=dict(
+                    weights=types.TensorData(data=weights, dtype="float32"),
+                    target_tokens=types.TensorData(data=target_tokens, dtype="int64"),
+                ),
+            )
+        )
+    return data
+
+
+def _make_model_config(**overrides) -> ModelConfig:
+    assert MODEL_PATH is not None
+    defaults: dict[str, Any] = dict(
+        model_name="test-fsdp",
+        model_path=MODEL_PATH,
+        max_model_len=2048,
+        tensor_parallel_size=1,
+        training_backend="fsdp",
+        num_gpus_per_node=NUM_FSDP_GPUS,
+        num_nodes=1,
+    )
+    defaults.update(overrides)
+    return ModelConfig(**defaults)
+
+
+# ------------------------------------------------------------------
+# Test 1: Basic FSDP2 training — loss should decrease
+# ------------------------------------------------------------------
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_training_loss_decrease(fsdp_ray_cluster):
+    """Create one adapter, train for a few steps, assert loss decreases."""
+    config = _make_model_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+
+    await backend.create_adapter("lora_a", types.LoraConfig(rank=8, seed=42))
+
+    data = _construct_data()
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+
+    losses = []
+    for step in range(4):
+        output = await backend.forward(
+            data=data,
+            lora_id="lora_a",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_a")
+        logprobs = np.concatenate([o["logprobs"].tolist() for o in output.loss_fn_outputs])
+        loss = -np.dot(logprobs, weights) / weights.sum()
+        losses.append(loss)
+        print(f"[FSDP] step {step} loss={loss:.4f}")
+
+    for i in range(1, len(losses)):
+        assert losses[i] < losses[i - 1], (
+            f"Loss did not decrease at step {i}: {losses[i]:.4f} >= {losses[i - 1]:.4f}"
+        )
+
+
+# ------------------------------------------------------------------
+# Test 2: Multi-tenant — two adapters trained concurrently
+# ------------------------------------------------------------------
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_multi_tenant(fsdp_ray_cluster):
+    """Two adapters trained in interleaved fashion; both losses should decrease."""
+    config = _make_model_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+
+    await backend.create_adapter("lora_1", types.LoraConfig(rank=8, seed=42))
+    await backend.create_adapter("lora_2", types.LoraConfig(rank=8, seed=42))
+
+    data = _construct_data()
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+
+    losses_1, losses_2 = [], []
+    for step in range(3):
+        out1 = await backend.forward(
+            data=data,
+            lora_id="lora_1",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        out2 = await backend.forward(
+            data=data,
+            lora_id="lora_2",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_1")
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_2")
+
+        lp1 = np.concatenate([o["logprobs"].tolist() for o in out1.loss_fn_outputs])
+        lp2 = np.concatenate([o["logprobs"].tolist() for o in out2.loss_fn_outputs])
+        loss1 = -np.dot(lp1, weights) / weights.sum()
+        loss2 = -np.dot(lp2, weights) / weights.sum()
+        losses_1.append(loss1)
+        losses_2.append(loss2)
+        print(f"[FSDP multi-tenant] step {step}  lora_1={loss1:.4f}  lora_2={loss2:.4f}")
+
+    for i in range(1, len(losses_1)):
+        assert losses_1[i] < losses_1[i - 1], "lora_1 loss did not decrease"
+        assert losses_2[i] < losses_2[i - 1], "lora_2 loss did not decrease"
+
+    assert abs(losses_1[-1] - losses_2[-1]) < 0.5, (
+        "Two identically-seeded LoRAs should have similar loss"
+    )
+
+
+# ------------------------------------------------------------------
+# Test 3: Checkpoint save & load
+# ------------------------------------------------------------------
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_checkpoint_save_load(fsdp_ray_cluster):
+    """Train, save checkpoint, load into new adapter, verify continuity."""
+    config = _make_model_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+
+    await backend.create_adapter("lora_ckpt", types.LoraConfig(rank=8, seed=42))
+    data = _construct_data()
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+
+    pre_losses = []
+    for step in range(3):
+        output = await backend.forward(
+            data=data,
+            lora_id="lora_ckpt",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_ckpt")
+        lp = np.concatenate([o["logprobs"].tolist() for o in output.loss_fn_outputs])
+        loss = -np.dot(lp, weights) / weights.sum()
+        pre_losses.append(loss)
+        print(f"[FSDP ckpt] pre-save step {step} loss={loss:.4f}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ckpt = CheckpointRecord(
+            checkpoint_id="lora_ckpt",
+            owner_name="default",
+            checkpoint_type="training",
+            path=Path(tmpdir) / "lora_ckpt",
+            training_run_id="test_run",
+            size_bytes=0,
+        )
+        await backend.save_state(lora_id="lora_ckpt", checkpoint_record=ckpt, optimizer=True)
+
+        await backend.load_state(lora_id="lora_loaded", checkpoint_record=ckpt, optimizer=True)
+
+        post_losses = []
+        for step in range(3, 6):
+            output = await backend.forward(
+                data=data,
+                lora_id="lora_loaded",
+                loss_fn="cross_entropy",
+                loss_fn_config=None,
+                backward=True,
+            )
+            await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_loaded")
+            lp = np.concatenate([o["logprobs"].tolist() for o in output.loss_fn_outputs])
+            loss = -np.dot(lp, weights) / weights.sum()
+            post_losses.append(loss)
+            print(f"[FSDP ckpt] post-load step {step} loss={loss:.4f}")
+
+    assert post_losses[0] < pre_losses[-1] + 0.1, (
+        "Post-load loss should be close to or below pre-save loss"
+    )
+    for i in range(1, len(post_losses)):
+        assert post_losses[i] < post_losses[i - 1], "Post-load loss should keep decreasing"
+
+
+# ------------------------------------------------------------------
+# Test 4: Gradient accumulation isolation across adapter switches
+# ------------------------------------------------------------------
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_fsdp_gradient_isolation(fsdp_ray_cluster):
+    """Verify that gradient accumulation is properly isolated when
+    switching adapters between forward_backward calls.
+
+    Train lora_x with 2 forward_backward calls (gradient accumulation)
+    with an adapter switch in between, vs lora_y with 2 consecutive
+    forward_backward calls (no switch). Both should converge similarly.
+    """
+    config = _make_model_config()
+    backend = FSDPTrainingBackend(config)
+    await backend.async_init()
+
+    await backend.create_adapter("lora_x", types.LoraConfig(rank=8, seed=42))
+    await backend.create_adapter("lora_y", types.LoraConfig(rank=8, seed=42))
+    await backend.create_adapter("lora_dummy", types.LoraConfig(rank=8, seed=99))
+
+    data = _construct_data(name="default")
+    weights = np.concatenate([d.loss_fn_inputs["weights"].tolist() for d in data])
+
+    losses_x, losses_y = [], []
+    for step in range(3):
+        # lora_x: forward_backward → switch to dummy → switch back → forward_backward → optim
+        await backend.forward(
+            data=data,
+            lora_id="lora_x",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        # interleave with dummy adapter
+        await backend.forward(
+            data=data,
+            lora_id="lora_dummy",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_dummy")
+        out_x = await backend.forward(
+            data=data,
+            lora_id="lora_x",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_x")
+
+        # lora_y: two consecutive forward_backward → optim (no switch)
+        await backend.forward(
+            data=data,
+            lora_id="lora_y",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        out_y = await backend.forward(
+            data=data,
+            lora_id="lora_y",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="lora_y")
+
+        lp_x = np.concatenate([o["logprobs"].tolist() for o in out_x.loss_fn_outputs])
+        lp_y = np.concatenate([o["logprobs"].tolist() for o in out_y.loss_fn_outputs])
+        loss_x = -np.dot(lp_x, weights) / weights.sum()
+        loss_y = -np.dot(lp_y, weights) / weights.sum()
+        losses_x.append(loss_x)
+        losses_y.append(loss_y)
+        print(f"[grad iso] step {step}  lora_x={loss_x:.4f}  lora_y={loss_y:.4f}")
+
+    for i in range(1, len(losses_x)):
+        assert losses_x[i] < losses_x[i - 1], "lora_x loss should decrease"
+        assert losses_y[i] < losses_y[i - 1], "lora_y loss should decrease"

--- a/tests/test_fsdp_training.py
+++ b/tests/test_fsdp_training.py
@@ -9,13 +9,16 @@ Requires:
     - At least 2 GPUs available (FSDP_TEST_GPUS, default 2)
 """
 
+import pytest
+
+pytest.importorskip("torch", reason="FSDP tests require PyTorch")
+
 import os
 import tempfile
 from pathlib import Path
 from typing import Any, List
 
 import numpy as np
-import pytest
 import ray
 import transformers
 from tinker import types


### PR DESCRIPTION
Implement a fully-sharded data-parallel (FSDP2) training backend that distributes base models across multiple GPUs while supporting dynamic multi-tenant LoRA adapter management.

Core components:
- FSDPTrainingWorker: per-GPU worker handling model construction, FSDP2 wrapping (MixedPrecisionPolicy bfloat16/float32), and multi-tenant adapter lifecycle (create/switch/remove) with gradient isolation
- FSDPWorkerGroup: Ray-based orchestrator that manages worker actors, distributes data shards, and aggregates results across ranks
- FSDPTrainingBackend: async interface bridging the training controller to the FSDP worker group
- fsdp_utils: version-aware FSDP2 imports (PyTorch 2.4+), ABC compatibility patching for HuggingFace models, device mesh creation

Key design decisions:
- Pre-wrap all decoder-layer linears with a default LoRA adapter before FSDP2 sharding so that subsequent add_adapter calls use PEFT's update_layer (in-place weight addition) instead of _replace_module (which would break FSDP2 parameter tracking)
- LoRA parameters are regular tensors (not DTensors) and require explicit broadcast (init) and all_reduce (gradients) across ranks
- Per-adapter optimizer instances and saved gradient buffers enable decoupled forward/backward/optim_step across tenant switches

Tests:
- test_fsdp_training: basic loss decrease, multi-tenant isolation, checkpoint save/load, gradient isolation across adapters
- test_fsdp_e2e: end-to-end server + backend tests covering dynamic adapter lifecycle, checkpoint resume, rapid switching, memory stability, decoupled operations, cross-rank parameter sync
- test_fsdp_comprehensive: multi-rank adapters on one model, training state preservation across switches, sequential multi-model training, inference deployment via vLLM, GPU memory lifecycle monitoring

All test model paths are resolved from environment variables (TUFT_TEST_MODEL, FSDP_TEST_MODEL_A/B) with no hardcoded paths. Fixtures enforce >= 2 GPU availability and perform clear_ray_state before and after each test.