### PR TITLE
fix(checkpoints): enforce ownership/visibility for get_weights_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ We recommend using [uv](https://github.com/astral-sh/uv) for dependency manageme
 
     ```bash
     cd TuFT
-    bash scripts/net_check.sh
+    bash scripts/env_check.sh
     ```
     This script will assess your environment status and suggest possible solutions.
 

--- a/src/tuft/state.py
+++ b/src/tuft/state.py
@@ -12,9 +12,18 @@ from tinker import types
 from .auth import AuthenticationDB, User
 from .checkpoints import CheckpointRecord
 from .config import AppConfig
-from .exceptions import SessionNotFoundException, UserMismatchException
+from .exceptions import (
+    CheckpointAccessDeniedException,
+    SessionNotFoundException,
+    UserMismatchException,
+)
 from .futures import FutureStore
-from .persistence import get_redis_store, is_persistence_enabled, load_record, save_record
+from .persistence import (
+    get_redis_store,
+    is_persistence_enabled,
+    load_record,
+    save_record,
+)
 from .sampling_controller import SamplingController
 from .training_controller import TrainingController, TrainingRunRecord
 
@@ -293,8 +302,19 @@ class ServerState:
         )
 
     def get_weights_info(self, tinker_path: str, user_id: str) -> types.WeightsInfoResponse:
-        parsed = types.ParsedCheckpointTinkerPath.from_tinker_path(tinker_path)
-        return self.training.get_weights_info(parsed.training_run_id, user_id)
+        assert self.config.checkpoint_dir is not None
+        record = CheckpointRecord.from_tinker_path(tinker_path, self.config.checkpoint_dir)
+        metadata = record.metadata
+
+        # Enforce ownership / visibility
+        if not (metadata.public or metadata.owner_name == user_id):
+            raise CheckpointAccessDeniedException(checkpoint_id=record.checkpoint_id)
+
+        return types.WeightsInfoResponse(
+            base_model=metadata.base_model,
+            is_lora=True,
+            lora_rank=metadata.lora_rank,
+        )
 
     def build_archive_url(
         self,

--- a/tests/test_state_controllers.py
+++ b/tests/test_state_controllers.py
@@ -581,3 +581,43 @@ async def test_rest_client(request, tmp_path) -> None:
             sampler_id=sampler_1,
             user_id="other_user",
         )
+
+
+@pytest.mark.asyncio
+async def test_get_weights_info_respects_visibility(request, tmp_path) -> None:
+    use_gpu = request.config.getoption("--gpu")
+    state = _build_state(tmp_path, use_gpu)
+
+    # user A creates a run and checkpoint
+    session_id = _create_session(state, user_id="alice")
+    training = await state.create_model(
+        session_id,
+        model_owner="alice",
+        base_model="Qwen/Qwen3-0.6B",
+        lora_config=types.LoraConfig(rank=2),
+        user_metadata=None,
+    )
+    ckpt = await state.save_checkpoint(
+        training.training_run_id,
+        user_id="alice",
+        name="vis-test",
+        checkpoint_type="training",
+    )
+    tpath = ckpt.tinker_checkpoint.tinker_path
+
+    # user B should NOT access private checkpoint
+    with pytest.raises(CheckpointAccessDeniedException):
+        state.get_weights_info(tpath, user_id="bob")
+
+    # make checkpoint public
+    state.set_checkpoint_visibility(
+        training.training_run_id,
+        user_id="alice",
+        checkpoint_id="vis-test",
+        public=True,
+    )
+
+    # user B can access now
+    info = state.get_weights_info(tpath, user_id="bob")
+    assert info.base_model == "Qwen/Qwen3-0.6B"
+    assert info.is_lora is True


### PR DESCRIPTION
Fix `get_weights_info` to resolve checkpoint metadata from the tinker path and enforce checkpoint ownership/visibility, enabling correct behavior for public checkpoints across users.

Why?
Issue #6 asks to enforce ownership/visibility checks when loading/using checkpoints. This endpoint currently routes through training-run records rather than checkpoint metadata, which can incorrectly gate access.

Changes
- Resolve checkpoint via `CheckpointRecord.from_tinker_path(...)`
- Validate `public` OR `owner_name == user_id`
- Return `WeightsInfoResponse` using checkpoint metadata

Tests
- Added a test that verifies:
- private checkpoint blocks other user
- making checkpoint public allows other user to fetch weights info