### PR TITLE
fix: compatibility with both Tinker SDK 0.19.x and 0.20.x

### DIFF
--- a/src/tuft/compat.py
+++ b/src/tuft/compat.py
@@ -45,14 +45,52 @@ def serialize_sample_response(response: SampleResponse) -> dict[str, Any]:
     return result
 
 
-def maybe_serialize_payload(payload: Any) -> Any:
-    """If payload is a SampleResponse dataclass, serialize it to dict.
+def _serialize_tensor_data(td: Any) -> dict[str, Any]:
+    """Serialize a TensorData dataclass to a JSON-safe dict.
 
-    Other Pydantic-based types (ForwardBackwardOutput, OptimStepResponse, etc.)
-    are handled natively by FastAPI and need no conversion.
+    Uses ``td.data`` (returns list[int] | list[float]) instead of the
+    internal ``_numpy`` field which Pydantic cannot serialize.
     """
+    d: dict[str, Any] = {
+        "data": td.data,
+        "dtype": td.dtype,
+    }
+    if td.shape is not None:
+        d["shape"] = td.shape
+    if td.sparse_crow_indices is not None:
+        d["sparse_crow_indices"] = td.sparse_crow_indices
+    if td.sparse_col_indices is not None:
+        d["sparse_col_indices"] = td.sparse_col_indices
+    return d
+
+
+def _serialize_forward_backward_output(payload: Any) -> dict[str, Any]:
+    """Serialize a ForwardBackwardOutput dataclass to a JSON-safe dict."""
+    loss_fn_outputs = [
+        {k: _serialize_tensor_data(v) for k, v in datum.items()}
+        for datum in payload.loss_fn_outputs
+    ]
+    return {
+        "loss_fn_output_type": payload.loss_fn_output_type,
+        "loss_fn_outputs": loss_fn_outputs,
+        "metrics": payload.metrics,
+    }
+
+
+def maybe_serialize_payload(payload: Any) -> Any:
+    """If payload is a SampleResponse or ForwardBackwardOutput dataclass, serialize it to dict.
+
+    These dataclass types contain numpy arrays (TensorData._numpy) that
+    Pydantic cannot serialize, so we convert them to JSON-safe dicts.
+    Other Pydantic-based types (OptimStepResponse, etc.) are handled
+    natively by FastAPI and need no conversion.
+    """
+    from tinker.types.forward_backward_output import ForwardBackwardOutput
+
     if isinstance(payload, SampleResponse):
         return serialize_sample_response(payload)
+    if isinstance(payload, ForwardBackwardOutput):
+        return _serialize_forward_backward_output(payload)
     return payload
 
 

--- a/src/tuft/server.py
+++ b/src/tuft/server.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import timezone
 from functools import partial
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
@@ -15,10 +15,20 @@ from fastapi.security import APIKeyHeader
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import BaseModel
 from tinker import types
-from tinker.types import (
-    ForwardBackwardRequest as PydanticForwardBackwardRequest,
-    ForwardRequest as PydanticForwardRequest,
-)
+
+
+try:
+    from tinker.types._pydantic_types.forward_backward_request import (
+        ForwardBackwardRequest as PydanticForwardBackwardRequest,
+    )
+    from tinker.types._pydantic_types.forward_request import (
+        ForwardRequest as PydanticForwardRequest,
+    )
+except ModuleNotFoundError:
+    from tinker.types import (
+        ForwardBackwardRequest as PydanticForwardBackwardRequest,
+        ForwardRequest as PydanticForwardRequest,
+    )
 
 from .auth import User
 from .compat import maybe_serialize_payload, serialize_sample_response_proto
@@ -305,12 +315,13 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:
         inp = request.forward_input
+        data = cast(list[types.Datum], inp.data)
 
         async def _operation() -> types.ForwardBackwardOutput:
             return await state.run_forward(
                 request.model_id,
                 user.user_id,
-                inp.data,
+                data,
                 inp.loss_fn,
                 inp.loss_fn_config,
                 request.seq_id,
@@ -326,7 +337,7 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
             operation_args={
                 "model_id": request.model_id,
                 "user_id": user.user_id,
-                "data": inp.data,
+                "data": data,
                 "loss_fn": inp.loss_fn,
                 "loss_fn_config": inp.loss_fn_config,
                 "seq_id": request.seq_id,
@@ -345,12 +356,13 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:
         inp = request.forward_backward_input
+        data = cast(list[types.Datum], inp.data)
 
         async def _operation() -> types.ForwardBackwardOutput:
             return await state.run_forward(
                 request.model_id,
                 user.user_id,
-                inp.data,
+                data,
                 inp.loss_fn,
                 inp.loss_fn_config,
                 request.seq_id,

--- a/src/tuft/server.py
+++ b/src/tuft/server.py
@@ -15,6 +15,10 @@ from fastapi.security import APIKeyHeader
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import BaseModel
 from tinker import types
+from tinker.types import (
+    ForwardBackwardRequest as PydanticForwardBackwardRequest,
+    ForwardRequest as PydanticForwardRequest,
+)
 
 from .auth import User
 from .compat import maybe_serialize_payload, serialize_sample_response_proto
@@ -296,7 +300,7 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def forward(
-        request: types.ForwardRequest,
+        request: PydanticForwardRequest,
         state: ServerState = Depends(_get_state),
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:
@@ -336,7 +340,7 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def forward_backward(
-        request: types.ForwardBackwardRequest,
+        request: PydanticForwardBackwardRequest,
         state: ServerState = Depends(_get_state),
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:

--- a/src/tuft/server.py
+++ b/src/tuft/server.py
@@ -18,17 +18,11 @@ from tinker import types
 
 
 try:
-    from tinker.types._pydantic_types.forward_backward_request import (
-        ForwardBackwardRequest as PydanticForwardBackwardRequest,
-    )
-    from tinker.types._pydantic_types.forward_request import (
-        ForwardRequest as PydanticForwardRequest,
-    )
+    from tinker.types._pydantic_types.forward_backward_request import ForwardBackwardRequest
+    from tinker.types._pydantic_types.forward_request import ForwardRequest
+
 except ModuleNotFoundError:
-    from tinker.types import (
-        ForwardBackwardRequest as PydanticForwardBackwardRequest,
-        ForwardRequest as PydanticForwardRequest,
-    )
+    from tinker.types import ForwardBackwardRequest, ForwardRequest
 
 from .auth import User
 from .compat import maybe_serialize_payload, serialize_sample_response_proto
@@ -310,7 +304,7 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def forward(
-        request: PydanticForwardRequest,
+        request: ForwardRequest,
         state: ServerState = Depends(_get_state),
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:
@@ -351,7 +345,7 @@ def create_root_app(config: AppConfig | None = None) -> FastAPI:
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def forward_backward(
-        request: PydanticForwardBackwardRequest,
+        request: ForwardBackwardRequest,
         state: ServerState = Depends(_get_state),
         user: User = Depends(_get_user),
     ) -> types.UntypedAPIFuture:


### PR DESCRIPTION
## Background & Problem
Tinker SDK 0.20.0 introduced breaking changes that prevented users on 0.19.x from running correctly:
**Module path change:** The Pydantic types `ForwardRequest` and `ForwardBackwardRequest` were moved from `tinker.types` to the `tinker.types._pydantic_types.* `submodule, causing a ModuleNotFoundError on older versions.
**Pydantic v2 serialization failure**: ForwardBackwardOutput contains TensorData dataclasses with an internal _numpy field (a numpy array) that Pydantic v2 cannot serialize to JSON, causing response serialization to fail.
## Changes
`src/tuft/server.py`
Added a try/except ModuleNotFoundError block to support both import paths: _pydantic_types submodule (0.20.0+) and tinker.types directly (0.19.x).
Updated type annotations for forward and forward_backward endpoints to use the version-adapted Pydantic types, with cast to preserve internal type consistency.
`src/tuft/compat.py`
Added _serialize_tensor_data(): serializes a TensorData dataclass to a JSON-safe dict using the .data property (list[int] / list[float]) instead of the non-serializable _numpy field.
Added _serialize_forward_backward_output(): provides full custom serialization for ForwardBackwardOutput.
Extended maybe_serialize_payload(): now handles ForwardBackwardOutput in addition to the existing SampleResponse case.