### PR TITLE
feat(sampling): support vLLM tool calling and reasoning parser

### DIFF
--- a/config/tuft_config.example.yaml
+++ b/config/tuft_config.example.yaml
@@ -41,6 +41,9 @@ model_owner: local-user
 #   - colocate: Colocate sampling and training on same device (default: false)
 #   - sampling_memory_fraction: GPU memory fraction for sampling (default: 0.2)
 #   - quantization: Quantization method for sampling (default: none)
+#   - enable_auto_tool_choice: vLLM OpenAI API auto tool choice (qwenpaw ReAct)
+#   - tool_call_parser: vLLM tool parser (e.g. hermes for Qwen3-Thinking)
+#   - reasoning_parser: vLLM reasoning parser (e.g. qwen3)
 
 supported_models:
   - model_name: Qwen/Qwen3-4B

--- a/src/tuft/backends/sampling_backend.py
+++ b/src/tuft/backends/sampling_backend.py
@@ -196,9 +196,42 @@ class VLLMSamplingBackend(BaseSamplingBackend):
         else:
             return self._create_standalone_engine(config)
 
+    def _build_inference_model_config(self, config: ModelConfig, **extra_kwargs):
+        from trinity.common.config import InferenceModelConfig
+
+        return InferenceModelConfig(
+            model_path=str(config.model_path),
+            tensor_parallel_size=extra_kwargs.pop("tensor_parallel_size"),
+            max_model_len=(
+                config.sampling_max_model_len
+                if config.sampling_max_model_len is not None
+                else config.max_model_len
+            ),
+            temperature=config.temperature,
+            top_p=config.top_p,
+            top_k=config.top_k,
+            logprobs=config.logprobs,
+            min_response_tokens=config.min_response_tokens,
+            repetition_penalty=1.0,
+            enable_lora=True,
+            enable_runtime_lora_updating=True,
+            enable_openai_api=True,
+            enable_auto_tool_choice=config.enable_auto_tool_choice,
+            tool_call_parser=config.tool_call_parser,
+            reasoning_parser=config.reasoning_parser,
+            lora_kwargs={
+                "max_lora_rank": config.max_lora_rank,
+                "max_loras": config.max_loras,
+                **({"quantization": config.quantization} if config.quantization else {}),
+            },
+            gpu_memory_utilization=extra_kwargs.pop(
+                "gpu_memory_utilization", config.sampling_memory_fraction
+            ),
+            **extra_kwargs,
+        )
+
     def _create_colocated_engine(self, config: ModelConfig):
         import ray
-        from trinity.common.config import InferenceModelConfig
         from trinity.common.models.vllm_model import vLLMRolloutModel
 
         if not self._worker_venv_path or not self._worker_venv_path.strip():
@@ -221,29 +254,9 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                 runtime_env=_runtime_env,
             )
             .remote(
-                config=InferenceModelConfig(
-                    model_path=str(config.model_path),
+                config=self._build_inference_model_config(
+                    config,
                     tensor_parallel_size=1,
-                    max_model_len=(
-                        config.sampling_max_model_len
-                        if config.sampling_max_model_len is not None
-                        else config.max_model_len
-                    ),
-                    temperature=config.temperature,
-                    top_p=config.top_p,
-                    top_k=config.top_k,
-                    logprobs=config.logprobs,
-                    min_response_tokens=config.min_response_tokens,
-                    repetition_penalty=1.0,
-                    enable_lora=True,
-                    enable_runtime_lora_updating=True,
-                    enable_openai_api=True,
-                    lora_kwargs={
-                        "max_lora_rank": config.max_lora_rank,
-                        "max_loras": config.max_loras,
-                        **({"quantization": config.quantization} if config.quantization else {}),
-                    },
-                    # sampling use less memory than training
                     gpu_memory_utilization=config.sampling_memory_fraction,
                 )
             )
@@ -251,7 +264,6 @@ class VLLMSamplingBackend(BaseSamplingBackend):
 
     def _create_standalone_engine(self, config: ModelConfig):
         import ray
-        from trinity.common.config import InferenceModelConfig
         from trinity.common.models.vllm_model import vLLMRolloutModel
 
         # Assign tensor_parallel_size GPUs to the actor itself
@@ -281,29 +293,9 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                 runtime_env=_runtime_env,
             )
             .remote(
-                config=InferenceModelConfig(
-                    model_path=str(config.model_path),
+                config=self._build_inference_model_config(
+                    config,
                     tensor_parallel_size=config.tensor_parallel_size,
-                    max_model_len=(
-                        config.sampling_max_model_len
-                        if config.sampling_max_model_len is not None
-                        else config.max_model_len
-                    ),
-                    temperature=config.temperature,
-                    top_p=config.top_p,
-                    top_k=config.top_k,
-                    logprobs=config.logprobs,
-                    min_response_tokens=config.min_response_tokens,
-                    repetition_penalty=1.0,
-                    enable_lora=True,
-                    enable_runtime_lora_updating=True,
-                    enable_openai_api=True,
-                    lora_kwargs={
-                        "max_lora_rank": config.max_lora_rank,
-                        "max_loras": config.max_loras,
-                        **({"quantization": config.quantization} if config.quantization else {}),
-                    },
-                    gpu_memory_utilization=config.sampling_memory_fraction,
                     bundle_indices=bundle_indices,
                 )
             )

--- a/src/tuft/config.py
+++ b/src/tuft/config.py
@@ -78,6 +78,11 @@ class ModelConfig(BaseModel):
     # Can be set smaller (e.g. 2048) in testing to reduce GPU memory and startup time.
     sampling_max_model_len: int | None = None
 
+    # OpenAI-compatible vLLM API: tool calling (required for qwenpaw ReAct agents).
+    enable_auto_tool_choice: bool = False
+    tool_call_parser: str | None = None
+    reasoning_parser: str | None = None
+
     @model_validator(mode="after")
     def validate_colocate(self) -> "ModelConfig":
         if self.colocate and self.tensor_parallel_size != 1:
@@ -89,6 +94,15 @@ class ModelConfig(BaseModel):
         """Ensure fsdp_rank_slots keys are int (YAML/JSON may load them as str)."""
         if self.fsdp_rank_slots is not None and len(self.fsdp_rank_slots) > 0:
             self.fsdp_rank_slots = {int(k): v for k, v in self.fsdp_rank_slots.items()}
+        return self
+
+    @model_validator(mode="after")
+    def validate_tool_calling(self) -> "ModelConfig":
+        if self.enable_auto_tool_choice and not self.tool_call_parser:
+            raise ValueError(
+                "enable_auto_tool_choice requires tool_call_parser "
+                "(e.g. hermes for Qwen3-Thinking models)."
+            )
         return self
 
 


### PR DESCRIPTION
- Add enable_auto_tool_choice / tool_call_parser / reasoning_parser fields to ModelConfig, with validator requiring tool_call_parser when auto tool choice is enabled (e.g. hermes for Qwen3-Thinking).
- Wire the new fields into VLLMSamplingBackend by extracting the duplicated InferenceModelConfig construction in colocated/standalone engines into a shared _build_inference_model_config helper.
- Document the new options in tuft_config.example.yaml.