### PR TITLE
feat: add Data Parallel inference support for small models

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -126,27 +126,6 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {
-    "examples/chat_sft.ipynb": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "examples/chat_sft.ipynb",
-        "hashed_secret": "6934525fb680ad0b8557b3f142dd5f8b2faeade1",
-        "is_verified": false,
-        "line_number": 646,
-        "is_secret": false
-      }
-    ],
-    "examples/countdown_rl.ipynb": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "examples/countdown_rl.ipynb",
-        "hashed_secret": "442d0cab01db9e869e916f2bbcbfd1e084d5c64a",
-        "is_verified": false,
-        "line_number": 1882,
-        "is_secret": false
-      }
-    ]
-  },
-  "generated_at": "2026-01-28T21:20:52Z"
+  "results": {},
+  "generated_at": "2026-06-18T03:37:49Z"
 }

--- a/src/tuft/backends/__init__.py
+++ b/src/tuft/backends/__init__.py
@@ -1,10 +1,11 @@
 from .fsdp_training_backend import FSDPTrainingBackend
-from .sampling_backend import BaseSamplingBackend, VLLMSamplingBackend
+from .sampling_backend import BaseSamplingBackend, DPSamplingBackend, VLLMSamplingBackend
 from .training_backend import BaseTrainingBackend, HFTrainingBackend
 
 
 __all__ = [
     "BaseSamplingBackend",
+    "DPSamplingBackend",
     "VLLMSamplingBackend",
     "BaseTrainingBackend",
     "HFTrainingBackend",

--- a/src/tuft/backends/base_backend.py
+++ b/src/tuft/backends/base_backend.py
@@ -55,12 +55,17 @@ class BaseSamplingBackend(BaseBackend):
         """Factory method to create a sampling backend instance.
 
         TUFT_CPU_TEST=1: use DummySamplingBackend (no vLLM, for CPU-only unit tests).
+        data_parallel_size > 1: use DPSamplingBackend (multiple vLLM instances with LB).
         Otherwise: VLLMSamplingBackend (creates Ray/vLLM actor in __init__, may block startup).
         """
         if os.getenv("TUFT_CPU_TEST", "0") == "1":
             from ..backends.sampling_backend import DummySamplingBackend
 
             return DummySamplingBackend(config)
+        if config.data_parallel_size > 1:
+            from ..backends.sampling_backend import DPSamplingBackend
+
+            return DPSamplingBackend(config, worker_venv_path=worker_venv_path)
         from ..backends.sampling_backend import VLLMSamplingBackend
 
         return VLLMSamplingBackend(config, worker_venv_path=worker_venv_path)

--- a/src/tuft/backends/sampling_backend.py
+++ b/src/tuft/backends/sampling_backend.py
@@ -179,11 +179,18 @@ class VLLMSamplingBackend(BaseSamplingBackend):
     `compute_logprobs_async` are all supported by the sample method.
     """
 
-    def __init__(self, config: ModelConfig, worker_venv_path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        config: ModelConfig,
+        worker_venv_path: Optional[str] = None,
+        *,
+        instance_index: int = 0,
+    ) -> None:
         from vllm.lora.request import LoRARequest
 
         super().__init__(config)
         self._worker_venv_path = worker_venv_path
+        self._instance_index = instance_index
         self.engine = self._create_engine(config)
         self.lora_adapters: dict[str, LoRARequest] = {}
         self._counter = 1
@@ -285,10 +292,21 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                     "PATH": f"{self._worker_venv_path}/bin:{_path}",
                 },
             }
+
+        # Use instance_index to differentiate Ray actor names for DP replicas
+        actor_name = f"sampling_model_{self.base_model}"
+        if self._instance_index > 0:
+            actor_name = f"{actor_name}_dp{self._instance_index}"
+
+        # In standalone/DP mode, each vLLM instance has a dedicated GPU.
+        # Use 0.9 (vLLM default) for max KV cache, not sampling_memory_fraction
+        # which is designed for colocate mode (shared GPU with training).
+        standalone_gpu_memory_utilization = 0.9
+
         return (
             ray.remote(vLLMRolloutModel)
             .options(
-                name="sampling_model_" + self.base_model,
+                name=actor_name,
                 num_gpus=num_gpus,
                 runtime_env=_runtime_env,
             )
@@ -297,6 +315,7 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                     config,
                     tensor_parallel_size=config.tensor_parallel_size,
                     bundle_indices=bundle_indices,
+                    gpu_memory_utilization=standalone_gpu_memory_utilization,
                 )
             )
         )
@@ -452,6 +471,105 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                 if lora_id in self.lora_adapters:
                     await self.engine.remove_lora_adapter.remote(lora_id)  # type: ignore[attr-defined]
                     del self.lora_adapters[lora_id]
+
+
+class DPSamplingBackend(BaseSamplingBackend):
+    """Data-Parallel sampling backend: N independent vLLM instances with round-robin LB.
+
+    Each instance runs on its own GPU(s) (tensor_parallel_size per instance).
+    Requests are distributed across instances using round-robin for uniform load.
+    All instances share the same LoRA adapters.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        worker_venv_path: Optional[str] = None,
+    ) -> None:
+        super().__init__(config)
+        self._dp_size = config.data_parallel_size
+        self._instances: list[VLLMSamplingBackend] = []
+        for i in range(self._dp_size):
+            instance = VLLMSamplingBackend(
+                config, worker_venv_path=worker_venv_path, instance_index=i
+            )
+            self._instances.append(instance)
+        # Atomic round-robin counter
+        self._rr_counter = 0
+        self._rr_lock = asyncio.Lock()
+        logger.info(
+            "DPSamplingBackend: created %d instances for model %s",
+            self._dp_size,
+            config.model_name,
+        )
+
+    def _next_instance(self) -> VLLMSamplingBackend:
+        """Round-robin selection (no lock needed for simple modular arithmetic)."""
+        idx = self._rr_counter % self._dp_size
+        self._rr_counter += 1
+        return self._instances[idx]
+
+    async def async_init(self) -> None:
+        """Initialize all DP instances in parallel."""
+        await asyncio.gather(*[inst.async_init() for inst in self._instances])
+        logger.info(
+            "DPSamplingBackend: all %d instances initialized for model %s",
+            self._dp_size,
+            self.base_model,
+        )
+
+    def get_openai_api_url(self) -> Optional[str]:
+        """Return a single URL (first instance) for backward compat.
+
+        For DP-aware routing, use get_openai_api_urls() instead.
+        """
+        return self._instances[0].get_openai_api_url() if self._instances else None
+
+    def get_openai_api_urls(self) -> list[str]:
+        """Return all vLLM instance URLs for DP-aware load balancing."""
+        urls = []
+        for inst in self._instances:
+            url = inst.get_openai_api_url()
+            if url:
+                urls.append(url)
+        return urls
+
+    def get_next_openai_api_url(self) -> Optional[str]:
+        """Return the next URL via round-robin for load-balanced proxying."""
+        inst = self._next_instance()
+        return inst.get_openai_api_url()
+
+    async def sample(
+        self,
+        prompt: types.ModelInput,
+        num_samples: int,
+        sampling_params: types.SamplingParams,
+        include_prompt_logprobs: bool = False,
+        topk_prompt_logprobs: int = 0,
+        lora_id: Optional[str] = None,
+    ) -> types.SampleResponse:
+        """Route sampling to a DP instance via round-robin."""
+        instance = self._next_instance()
+        return await instance.sample(
+            prompt=prompt,
+            num_samples=num_samples,
+            sampling_params=sampling_params,
+            include_prompt_logprobs=include_prompt_logprobs,
+            topk_prompt_logprobs=topk_prompt_logprobs,
+            lora_id=lora_id,
+        )
+
+    async def add_adapter(self, lora_id: str, adapter_path: Path) -> None:
+        """Add LoRA adapter to ALL DP instances."""
+        await asyncio.gather(
+            *[inst.add_adapter(lora_id, adapter_path) for inst in self._instances]
+        )
+
+    async def remove_adapter(self, lora_id: str) -> None:
+        """Remove LoRA adapter from ALL DP instances."""
+        await asyncio.gather(
+            *[inst.remove_adapter(lora_id) for inst in self._instances]
+        )
 
 
 def _build_mock_openai_app(model_name: str):

--- a/src/tuft/backends/sampling_backend.py
+++ b/src/tuft/backends/sampling_backend.py
@@ -561,15 +561,11 @@ class DPSamplingBackend(BaseSamplingBackend):
 
     async def add_adapter(self, lora_id: str, adapter_path: Path) -> None:
         """Add LoRA adapter to ALL DP instances."""
-        await asyncio.gather(
-            *[inst.add_adapter(lora_id, adapter_path) for inst in self._instances]
-        )
+        await asyncio.gather(*[inst.add_adapter(lora_id, adapter_path) for inst in self._instances])
 
     async def remove_adapter(self, lora_id: str) -> None:
         """Remove LoRA adapter from ALL DP instances."""
-        await asyncio.gather(
-            *[inst.remove_adapter(lora_id) for inst in self._instances]
-        )
+        await asyncio.gather(*[inst.remove_adapter(lora_id) for inst in self._instances])
 
 
 def _build_mock_openai_app(model_name: str):

--- a/src/tuft/config.py
+++ b/src/tuft/config.py
@@ -38,6 +38,10 @@ class ModelConfig(BaseModel):
     model_path: Path  # path to model checkpoint
     max_model_len: int  # maximum context length supported by the model
     tensor_parallel_size: int = 1  # tensor parallel size
+    # Data parallel size for inference: launch N independent vLLM instances (each with
+    # tensor_parallel_size GPUs) and load-balance requests across them.  Ideal for small
+    # models where TP introduces unnecessary cross-GPU communication overhead.
+    data_parallel_size: int = 1
 
     # default sampling parameters for this model
     temperature: float = 1.0
@@ -87,6 +91,8 @@ class ModelConfig(BaseModel):
     def validate_colocate(self) -> "ModelConfig":
         if self.colocate and self.tensor_parallel_size != 1:
             raise ValueError("Colocate option is only supported for tensor_parallel_size=1.")
+        if self.colocate and self.data_parallel_size > 1:
+            raise ValueError("Colocate option is not supported with data_parallel_size > 1.")
         return self
 
     @model_validator(mode="after")

--- a/src/tuft/oai/router.py
+++ b/src/tuft/oai/router.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..auth import User
-from ..backends.sampling_backend import DPSamplingBackend
+from ..backends.sampling_backend import BaseSamplingBackend, DPSamplingBackend
 from ..exceptions import (
     InvalidRequestException,
     ServerException,
@@ -201,10 +201,7 @@ def create_oai_router() -> APIRouter:
         if isinstance(backend, DPSamplingBackend):
             urls = backend.get_openai_api_urls()
             await asyncio.gather(
-                *[
-                    _ensure_lora_loaded(client, url, lora_name, lora_path)
-                    for url in urls
-                ]
+                *[_ensure_lora_loaded(client, url, lora_name, lora_path) for url in urls]
             )
         else:
             url = backend.get_openai_api_url()

--- a/src/tuft/oai/router.py
+++ b/src/tuft/oai/router.py
@@ -8,6 +8,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -17,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..auth import User
+from ..backends.sampling_backend import DPSamplingBackend
 from ..exceptions import (
     InvalidRequestException,
     ServerException,
@@ -152,7 +154,8 @@ def create_oai_router() -> APIRouter:
             }
         )
 
-    # Track which LoRA adapters have been loaded via the OpenAI API
+    # Track which LoRA adapters have been loaded via the OpenAI API.
+    # For DP mode, we track per (lora_name, backend_url) to ensure all instances are loaded.
     _loaded_loras: set[str] = set()
 
     async def _ensure_lora_loaded(
@@ -162,7 +165,9 @@ def create_oai_router() -> APIRouter:
         lora_path: str,
     ) -> None:
         """Load a LoRA adapter into vLLM's OpenAI serving layer if not already loaded."""
-        if lora_name in _loaded_loras:
+        # Use (lora_name, backend_url) as the cache key so DP instances are tracked individually
+        cache_key = f"{lora_name}@{backend_url}"
+        if cache_key in _loaded_loras:
             return
 
         url = f"{backend_url}/v1/load_lora_adapter"
@@ -173,18 +178,38 @@ def create_oai_router() -> APIRouter:
             timeout=60.0,
         )
         if resp.status_code == 200:
-            _loaded_loras.add(lora_name)
-            logger.info("Loaded LoRA '%s' via vLLM OpenAI API", lora_name)
+            _loaded_loras.add(cache_key)
+            logger.info("Loaded LoRA '%s' via vLLM OpenAI API at %s", lora_name, backend_url)
         else:
             # If 400 "already exists", that's fine
             body = resp.json() if resp.status_code < 500 else {}
             msg = body.get("message", "") if isinstance(body, dict) else str(body)
             if "already" in msg.lower():
-                _loaded_loras.add(lora_name)
+                _loaded_loras.add(cache_key)
                 return
             raise RuntimeError(
                 f"Failed to load LoRA adapter '{lora_name}': {resp.status_code} {resp.text}"
             )
+
+    async def _ensure_lora_loaded_all_dp(
+        client: httpx.AsyncClient,
+        backend: "BaseSamplingBackend",
+        lora_name: str,
+        lora_path: str,
+    ) -> None:
+        """Load LoRA on ALL DP instances (for DPSamplingBackend), or single instance otherwise."""
+        if isinstance(backend, DPSamplingBackend):
+            urls = backend.get_openai_api_urls()
+            await asyncio.gather(
+                *[
+                    _ensure_lora_loaded(client, url, lora_name, lora_path)
+                    for url in urls
+                ]
+            )
+        else:
+            url = backend.get_openai_api_url()
+            if url:
+                await _ensure_lora_loaded(client, url, lora_name, lora_path)
 
     async def _proxy_inference(
         request: Request,
@@ -218,23 +243,26 @@ def create_oai_router() -> APIRouter:
                 if resolved.lora_id:
                     span.set_attribute("oai.lora_id", resolved.lora_id)
 
-                # Get backend OpenAI URL
+                # Get backend OpenAI URL (DP-aware: round-robin across instances)
                 backend = state.sampling._base_backends.get(resolved.base_model)
                 if backend is None:
                     raise UnknownModelException(model_name=resolved.base_model)
 
-                backend_url = backend.get_openai_api_url()
+                if isinstance(backend, DPSamplingBackend):
+                    backend_url = backend.get_next_openai_api_url()
+                else:
+                    backend_url = backend.get_openai_api_url()
                 if backend_url is None:
                     raise ServiceUnavailableException(
                         f"OpenAI API not available for model: {resolved.base_model}"
                     )
 
-                # Ensure LoRA is loaded via the vLLM OpenAI server's API
+                # Ensure LoRA is loaded on ALL DP instances via the vLLM OpenAI API
                 if resolved.lora_adapter_path and resolved.lora_id:
                     try:
-                        await _ensure_lora_loaded(
+                        await _ensure_lora_loaded_all_dp(
                             client=client,
-                            backend_url=backend_url,
+                            backend=backend,
                             lora_name=resolved.lora_id,
                             lora_path=str(resolved.lora_adapter_path),
                         )

--- a/tests/test_data_parallel.py
+++ b/tests/test_data_parallel.py
@@ -13,8 +13,6 @@ Or directly:
 
 from __future__ import annotations
 
-import asyncio
-import json
 import os
 import subprocess
 import time
@@ -25,6 +23,7 @@ import pytest
 import tinker
 from tinker import types
 from transformers import AutoTokenizer
+
 
 # Configuration (can be overridden via env vars)
 BASE_URL = os.getenv("TUFT_BASE_URL", "http://localhost:10610")
@@ -55,7 +54,11 @@ def get_gpu_utilization():
     for line in result.stdout.strip().split("\n"):
         parts = [p.strip() for p in line.split(",")]
         gpus.append(
-            {"index": int(parts[0]), "memory_used_mib": int(parts[1]), "gpu_util_pct": int(parts[2])}
+            {
+                "index": int(parts[0]),
+                "memory_used_mib": int(parts[1]),
+                "gpu_util_pct": int(parts[2]),
+            }
         )
     return gpus
 
@@ -65,7 +68,10 @@ def send_chat_request(client: httpx.Client, request_id: int) -> dict:
     payload = {
         "model": BASE_MODEL,
         "messages": [
-            {"role": "user", "content": f"Write a short poem about the number {request_id}. Be creative."}
+            {
+                "role": "user",
+                "content": f"Write a short poem about the number {request_id}. Be creative.",
+            }
         ],
         "max_tokens": 200,
         "temperature": 0.8,
@@ -99,14 +105,17 @@ def test_concurrent_inference():
     print("=" * 70)
     print(f"  Sending {NUM_CONCURRENT_REQUESTS} concurrent requests to {BASE_URL}")
     print(f"  Model: {BASE_MODEL}")
-    print(f"  Expected: requests distributed across 4 DP vLLM instances")
+    print("  Expected: requests distributed across 4 DP vLLM instances")
     print()
 
     # Check GPU state before
     print("[Before] GPU utilization:")
     for gpu in get_gpu_utilization():
         status = "LOADED" if gpu["memory_used_mib"] > 5000 else "idle"
-        print(f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+        print(
+            f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB"
+            f"  util={gpu['gpu_util_pct']}%  [{status}]"
+        )
     print()
 
     # Send concurrent requests
@@ -147,7 +156,10 @@ def test_concurrent_inference():
     print("[After] GPU utilization:")
     for gpu in get_gpu_utilization():
         status = "LOADED" if gpu["memory_used_mib"] > 5000 else "idle"
-        print(f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+        print(
+            f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB"
+            f"  util={gpu['gpu_util_pct']}%  [{status}]"
+        )
     print()
 
     # Verify: all requests should succeed
@@ -175,7 +187,7 @@ def test_training():
         train_attn=True,
         train_unembed=True,
     )
-    print(f"  Created LoRA training client (rank=8)")
+    print("  Created LoRA training client (rank=8)")
 
     # Prepare a training datum
     messages = [
@@ -197,9 +209,7 @@ def test_training():
             "target_tokens": types.TensorData(
                 data=target_tokens, dtype="int64", shape=[len(target_tokens)]
             ),
-            "weights": types.TensorData(
-                data=weights, dtype="float32", shape=[len(weights)]
-            ),
+            "weights": types.TensorData(data=weights, dtype="float32", shape=[len(weights)]),
         },
     )
     print(f"  Prepared training datum: {len(input_tokens)} input tokens")
@@ -224,7 +234,7 @@ def test_training():
         adam_params=types.AdamParams(learning_rate=1e-4)
     ).result()
     optim_time = time.perf_counter() - start
-    grad_norm = getattr(optim_resp, 'grad_norm', None) or getattr(optim_resp, 'gradient_norm', None)
+    grad_norm = getattr(optim_resp, "grad_norm", None) or getattr(optim_resp, "gradient_norm", None)
     print(f"  Optim step completed in {optim_time:.2f}s")
     if grad_norm is not None:
         print(f"  Grad norm: {grad_norm:.4f}")
@@ -236,7 +246,10 @@ def test_training():
 
 
 def test_inference_after_training():
-    """Test 3: Verify inference still works after training (save weights + sample via tinker SDK)."""
+    """Test 3: Verify inference still works after training.
+
+    Saves weights and samples via tinker SDK.
+    """
     print("=" * 70)
     print("TEST 3: Save Weights & Sample via tinker SDK (inference after training)")
     print("=" * 70)
@@ -262,7 +275,9 @@ def test_inference_after_training():
     sampling_client = service_client.create_sampling_client(model_path=save_result.path)
 
     messages = [{"role": "user", "content": "Explain data parallelism in one sentence."}]
-    prompt_text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    prompt_text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
     prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=False)
 
     start = time.perf_counter()
@@ -312,8 +327,10 @@ def test_oai_lora_dp_routing():
     # With 4 DP instances and round-robin, this ensures each instance gets at least 2 requests.
     # If LoRA is not loaded on all instances, some requests will fail.
     num_requests = 8
-    print(f"  Sending {num_requests} OAI requests with LoRA model (round-robin across 4 DP instances)")
-    print(f"  Each instance should handle ~2 requests with the LoRA adapter loaded.")
+    print(
+        f"  Sending {num_requests} OAI requests with LoRA model (round-robin across 4 DP instances)"
+    )
+    print("  Each instance should handle ~2 requests with the LoRA adapter loaded.")
     print()
 
     results = []
@@ -333,13 +350,15 @@ def test_oai_lora_dp_routing():
                 timeout=120.0,
             )
             elapsed = time.perf_counter() - start
-            results.append({
-                "id": i,
-                "status": resp.status_code,
-                "elapsed": round(elapsed, 2),
-                "ok": resp.status_code == 200,
-                "detail": resp.json().get("detail", "")[:80] if resp.status_code != 200 else "",
-            })
+            results.append(
+                {
+                    "id": i,
+                    "status": resp.status_code,
+                    "elapsed": round(elapsed, 2),
+                    "ok": resp.status_code == 200,
+                    "detail": resp.json().get("detail", "")[:80] if resp.status_code != 200 else "",
+                }
+            )
 
     successes = sum(1 for r in results if r["ok"])
     failures = num_requests - successes
@@ -368,11 +387,10 @@ def test_sustained_concurrent_load():
     concurrency = 14  # 2 requests per DP instance in flight at any time
     print(f"  Duration: {duration_seconds}s")
     print(f"  Concurrency: {concurrency} in-flight requests")
-    print(f"  DP instances: 7 (each handling ~2 concurrent requests)")
+    print("  DP instances: 7 (each handling ~2 concurrent requests)")
     print()
 
     results = []
-    errors = []
     start_time = time.perf_counter()
     request_counter = [0]  # mutable counter for threads
 
@@ -382,7 +400,10 @@ def test_sustained_concurrent_load():
         payload = {
             "model": BASE_MODEL,
             "messages": [
-                {"role": "user", "content": f"Write a creative haiku about number {req_id % 100}. Be brief."}
+                {
+                    "role": "user",
+                    "content": f"Write a creative haiku about number {req_id % 100}. Be brief.",
+                }
             ],
             "max_tokens": 128,
             "temperature": 0.9,
@@ -396,7 +417,12 @@ def test_sustained_concurrent_load():
                 timeout=120.0,
             )
             elapsed = time.perf_counter() - req_start
-            return {"id": req_id, "status": resp.status_code, "elapsed": elapsed, "ok": resp.status_code == 200}
+            return {
+                "id": req_id,
+                "status": resp.status_code,
+                "elapsed": elapsed,
+                "ok": resp.status_code == 200,
+            }
         except Exception as e:
             elapsed = time.perf_counter() - req_start
             return {"id": req_id, "status": 0, "elapsed": elapsed, "ok": False, "error": str(e)}
@@ -415,7 +441,10 @@ def test_sustained_concurrent_load():
                     futures.remove(f)
 
                 # Submit new requests to maintain concurrency
-                while len(futures) < concurrency and (time.perf_counter() - start_time) < duration_seconds:
+                while (
+                    len(futures) < concurrency
+                    and (time.perf_counter() - start_time) < duration_seconds
+                ):
                     futures.append(executor.submit(send_request, client))
 
                 time.sleep(0.05)  # Small sleep to avoid busy-waiting
@@ -432,7 +461,7 @@ def test_sustained_concurrent_load():
     p99 = sorted(r["elapsed"] for r in results)[int(len(results) * 0.99)] if results else 0
     throughput = len(results) / total_time
 
-    print(f"  === Results ===")
+    print("  === Results ===")
     print(f"  Total requests:  {len(results)}")
     print(f"  Successes:       {successes}/{len(results)}")
     print(f"  Failures:        {failures}")
@@ -446,8 +475,15 @@ def test_sustained_concurrent_load():
     # Check GPU utilization
     print("  [Final] GPU utilization:")
     for gpu in get_gpu_utilization():
-        status = "ACTIVE" if gpu["gpu_util_pct"] > 0 else ("LOADED" if gpu["memory_used_mib"] > 5000 else "idle")
-        print(f"    GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+        status = (
+            "ACTIVE"
+            if gpu["gpu_util_pct"] > 0
+            else ("LOADED" if gpu["memory_used_mib"] > 5000 else "idle")
+        )
+        print(
+            f"    GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB"
+            f"  util={gpu['gpu_util_pct']}%  [{status}]"
+        )
     print()
 
     assert successes == len(results), f"{failures} requests failed"
@@ -462,8 +498,8 @@ def main():
     print("=" * 70)
     print(f"  Server: {BASE_URL}")
     print(f"  Model: {BASE_MODEL}")
-    print(f"  Config: data_parallel_size=7, tensor_parallel_size=1, fsdp_num_gpus=1")
-    print(f"  GPU layout: GPU 0 = training, GPU 1-7 = inference DP instances")
+    print("  Config: data_parallel_size=7, tensor_parallel_size=1, fsdp_num_gpus=1")
+    print("  GPU layout: GPU 0 = training, GPU 1-7 = inference DP instances")
     print()
 
     all_pass = True

--- a/tests/test_data_parallel.py
+++ b/tests/test_data_parallel.py
@@ -1,0 +1,517 @@
+"""Integration tests for Data Parallel inference load balancing and training.
+
+These tests require:
+- A running TuFT server with data_parallel_size > 1
+- Multiple GPUs available
+
+Run with:
+    pytest tests/test_data_parallel.py -m integration -v
+
+Or directly:
+    python tests/test_data_parallel.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import httpx
+import pytest
+import tinker
+from tinker import types
+from transformers import AutoTokenizer
+
+# Configuration (can be overridden via env vars)
+BASE_URL = os.getenv("TUFT_BASE_URL", "http://localhost:10610")
+API_KEY = os.getenv("TUFT_API_KEY", "tml-tuft-dev-key")
+BASE_MODEL = os.getenv("TUFT_BASE_MODEL", "Qwen/Qwen3-4B-Thinking-2507")
+MODEL_PATH = os.getenv("TUFT_MODEL_PATH", "/mnt/workspace/shared/qwen/Qwen3-4B-Thinking-2507")
+NUM_CONCURRENT_REQUESTS = 16  # Send enough requests to hit all DP instances
+
+# Mark all tests as integration (require running server + GPU)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.gpu,
+]
+
+
+def get_gpu_utilization():
+    """Get GPU memory and compute utilization."""
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=index,memory.used,utilization.gpu",
+            "--format=csv,noheader,nounits",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    gpus = []
+    for line in result.stdout.strip().split("\n"):
+        parts = [p.strip() for p in line.split(",")]
+        gpus.append(
+            {"index": int(parts[0]), "memory_used_mib": int(parts[1]), "gpu_util_pct": int(parts[2])}
+        )
+    return gpus
+
+
+def send_chat_request(client: httpx.Client, request_id: int) -> dict:
+    """Send a single chat completion request."""
+    payload = {
+        "model": BASE_MODEL,
+        "messages": [
+            {"role": "user", "content": f"Write a short poem about the number {request_id}. Be creative."}
+        ],
+        "max_tokens": 200,
+        "temperature": 0.8,
+    }
+    start = time.perf_counter()
+    resp = client.post(
+        f"{BASE_URL}/oai/api/v1/chat/completions",
+        json=payload,
+        headers={"X-API-Key": API_KEY},
+        timeout=120.0,
+    )
+    elapsed = time.perf_counter() - start
+    data = resp.json()
+    return {
+        "request_id": request_id,
+        "status": resp.status_code,
+        "elapsed_s": round(elapsed, 2),
+        "response_id": data.get("id", ""),
+        "content_preview": (
+            data.get("choices", [{}])[0].get("message", {}).get("content", "")[:80]
+            if resp.status_code == 200
+            else data.get("detail", str(data))[:80]
+        ),
+    }
+
+
+def test_concurrent_inference():
+    """Test 1: Send concurrent requests to verify DP load balancing."""
+    print("=" * 70)
+    print("TEST 1: Concurrent Inference Load Balancing (Data Parallel)")
+    print("=" * 70)
+    print(f"  Sending {NUM_CONCURRENT_REQUESTS} concurrent requests to {BASE_URL}")
+    print(f"  Model: {BASE_MODEL}")
+    print(f"  Expected: requests distributed across 4 DP vLLM instances")
+    print()
+
+    # Check GPU state before
+    print("[Before] GPU utilization:")
+    for gpu in get_gpu_utilization():
+        status = "LOADED" if gpu["memory_used_mib"] > 5000 else "idle"
+        print(f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+    print()
+
+    # Send concurrent requests
+    results = []
+    start_all = time.perf_counter()
+
+    with httpx.Client() as client:
+        with ThreadPoolExecutor(max_workers=NUM_CONCURRENT_REQUESTS) as executor:
+            futures = {
+                executor.submit(send_chat_request, client, i): i
+                for i in range(NUM_CONCURRENT_REQUESTS)
+            }
+            for future in as_completed(futures):
+                results.append(future.result())
+
+    total_time = time.perf_counter() - start_all
+    results.sort(key=lambda x: x["request_id"])
+
+    # Print results
+    print(f"[Results] {NUM_CONCURRENT_REQUESTS} requests completed in {total_time:.2f}s")
+    print()
+    successes = sum(1 for r in results if r["status"] == 200)
+    failures = NUM_CONCURRENT_REQUESTS - successes
+    print(f"  Successes: {successes}/{NUM_CONCURRENT_REQUESTS}")
+    if failures:
+        print(f"  Failures: {failures}")
+    print()
+
+    # Show first few results
+    print("  Sample responses:")
+    for r in results[:4]:
+        print(f"    req#{r['request_id']}: {r['elapsed_s']}s | id={r['response_id'][:50]}...")
+        print(f"      -> {r['content_preview'][:60]}...")
+    print()
+
+    # Check GPU state during/after (need a small delay for nvidia-smi to capture)
+    time.sleep(1)
+    print("[After] GPU utilization:")
+    for gpu in get_gpu_utilization():
+        status = "LOADED" if gpu["memory_used_mib"] > 5000 else "idle"
+        print(f"  GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+    print()
+
+    # Verify: all requests should succeed
+    assert successes == NUM_CONCURRENT_REQUESTS, f"Some requests failed: {failures} failures"
+    print("  [PASS] All concurrent inference requests succeeded")
+    print()
+    return True
+
+
+def test_training():
+    """Test 2: Verify training still works on its dedicated GPU."""
+    print("=" * 70)
+    print("TEST 2: Training (LoRA forward/backward + optim step)")
+    print("=" * 70)
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    service_client = tinker.ServiceClient(base_url=BASE_URL, api_key=API_KEY)
+    print(f"  Connected to {BASE_URL}")
+
+    # Create training client
+    training_client = service_client.create_lora_training_client(
+        base_model=BASE_MODEL,
+        rank=8,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+    print(f"  Created LoRA training client (rank=8)")
+
+    # Prepare a training datum
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "2+2 equals 4."},
+    ]
+    text = tokenizer.apply_chat_template(messages, tokenize=False)
+    tokens = tokenizer.encode(text, add_special_tokens=False)
+    # Shift: input = tokens[:-1], target = tokens[1:]
+    input_tokens = tokens[:-1]
+    target_tokens = tokens[1:]
+    # Simple weights: 0 for prompt prefix, 1 for last portion
+    n = len(target_tokens)
+    weights = [0.0] * max(0, n - 10) + [1.0] * min(10, n)
+
+    datum = types.Datum(
+        model_input=types.ModelInput.from_ints(input_tokens),
+        loss_fn_inputs={
+            "target_tokens": types.TensorData(
+                data=target_tokens, dtype="int64", shape=[len(target_tokens)]
+            ),
+            "weights": types.TensorData(
+                data=weights, dtype="float32", shape=[len(weights)]
+            ),
+        },
+    )
+    print(f"  Prepared training datum: {len(input_tokens)} input tokens")
+
+    # Forward + backward
+    start = time.perf_counter()
+    fb_output = training_client.forward_backward([datum], loss_fn="cross_entropy").result()
+    fb_time = time.perf_counter() - start
+    print(f"  Forward+Backward completed in {fb_time:.2f}s")
+
+    # Get loss value
+    loss_outputs = fb_output.loss_fn_outputs
+    if loss_outputs:
+        logprobs = loss_outputs[0].get("logprobs")
+        if logprobs and hasattr(logprobs, "data"):
+            avg_logprob = sum(logprobs.data) / max(len(logprobs.data), 1)
+            print(f"  Average logprob: {avg_logprob:.4f}")
+
+    # Optim step
+    start = time.perf_counter()
+    optim_resp = training_client.optim_step(
+        adam_params=types.AdamParams(learning_rate=1e-4)
+    ).result()
+    optim_time = time.perf_counter() - start
+    grad_norm = getattr(optim_resp, 'grad_norm', None) or getattr(optim_resp, 'gradient_norm', None)
+    print(f"  Optim step completed in {optim_time:.2f}s")
+    if grad_norm is not None:
+        print(f"  Grad norm: {grad_norm:.4f}")
+
+    print()
+    print("  [PASS] Training forward/backward + optim step succeeded")
+    print()
+    return True
+
+
+def test_inference_after_training():
+    """Test 3: Verify inference still works after training (save weights + sample via tinker SDK)."""
+    print("=" * 70)
+    print("TEST 3: Save Weights & Sample via tinker SDK (inference after training)")
+    print("=" * 70)
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    service_client = tinker.ServiceClient(base_url=BASE_URL, api_key=API_KEY)
+
+    training_client = service_client.create_lora_training_client(
+        base_model=BASE_MODEL,
+        rank=8,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+
+    # Save weights for sampler
+    start = time.perf_counter()
+    save_result = training_client.save_weights_for_sampler(name="dp-test-sampler").result()
+    save_time = time.perf_counter() - start
+    print(f"  Saved weights in {save_time:.2f}s, path={save_result.path}")
+
+    # Create sampling client and sample
+    sampling_client = service_client.create_sampling_client(model_path=save_result.path)
+
+    messages = [{"role": "user", "content": "Explain data parallelism in one sentence."}]
+    prompt_text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=False)
+
+    start = time.perf_counter()
+    sample_result = sampling_client.sample(
+        prompt=types.ModelInput.from_ints(prompt_tokens),
+        num_samples=1,
+        sampling_params=types.SamplingParams(max_tokens=128, temperature=0.7),
+    ).result()
+    sample_time = time.perf_counter() - start
+
+    response = tokenizer.decode(sample_result.sequences[0].tokens)
+    print(f"  Sampled in {sample_time:.2f}s")
+    print(f"  Response: {response[:200]}")
+    print()
+    print("  [PASS] Inference after training (tinker SDK path) succeeded")
+    print()
+    return True
+
+
+def test_oai_lora_dp_routing():
+    """Test 3b: Verify OAI API LoRA inference works across ALL DP instances.
+
+    This tests the fix for the bug where _ensure_lora_loaded() only loaded
+    the LoRA on one DP instance. We send multiple OAI requests with the
+    tinker:// model path, which should hit different DP instances via round-robin.
+    All must succeed for the fix to be validated.
+    """
+    print("=" * 70)
+    print("TEST 3b: OAI API LoRA Inference Across ALL DP Instances")
+    print("=" * 70)
+
+    service_client = tinker.ServiceClient(base_url=BASE_URL, api_key=API_KEY)
+
+    # Create training client and save weights to get a tinker:// path
+    training_client = service_client.create_lora_training_client(
+        base_model=BASE_MODEL,
+        rank=8,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+    save_result = training_client.save_weights_for_sampler(name="dp-oai-lora-test").result()
+    tinker_path = save_result.path
+    print(f"  LoRA saved at: {tinker_path}")
+
+    # Send 8 OAI requests using tinker:// path as model name.
+    # With 4 DP instances and round-robin, this ensures each instance gets at least 2 requests.
+    # If LoRA is not loaded on all instances, some requests will fail.
+    num_requests = 8
+    print(f"  Sending {num_requests} OAI requests with LoRA model (round-robin across 4 DP instances)")
+    print(f"  Each instance should handle ~2 requests with the LoRA adapter loaded.")
+    print()
+
+    results = []
+    with httpx.Client() as client:
+        for i in range(num_requests):
+            payload = {
+                "model": tinker_path,
+                "messages": [{"role": "user", "content": f"Say hello #{i}"}],
+                "max_tokens": 32,
+                "temperature": 0.5,
+            }
+            start = time.perf_counter()
+            resp = client.post(
+                f"{BASE_URL}/oai/api/v1/chat/completions",
+                json=payload,
+                headers={"X-API-Key": API_KEY},
+                timeout=120.0,
+            )
+            elapsed = time.perf_counter() - start
+            results.append({
+                "id": i,
+                "status": resp.status_code,
+                "elapsed": round(elapsed, 2),
+                "ok": resp.status_code == 200,
+                "detail": resp.json().get("detail", "")[:80] if resp.status_code != 200 else "",
+            })
+
+    successes = sum(1 for r in results if r["ok"])
+    failures = num_requests - successes
+    print(f"  Results: {successes}/{num_requests} succeeded")
+    for r in results:
+        status_str = "OK" if r["ok"] else f"FAIL({r['status']}: {r['detail']})"
+        print(f"    req#{r['id']}: {r['elapsed']}s [{status_str}]")
+    print()
+
+    if failures > 0:
+        print(f"  [FAIL] {failures} requests failed - LoRA not loaded on all DP instances!")
+        return False
+
+    print("  [PASS] All OAI LoRA requests succeeded across all DP instances")
+    print()
+    return True
+
+
+def test_sustained_concurrent_load():
+    """Test 4: Sustained concurrent load for 30 seconds to show all GPUs active."""
+    print("=" * 70)
+    print("TEST 4: Sustained Concurrent Load (30 seconds)")
+    print("=" * 70)
+
+    duration_seconds = 30
+    concurrency = 14  # 2 requests per DP instance in flight at any time
+    print(f"  Duration: {duration_seconds}s")
+    print(f"  Concurrency: {concurrency} in-flight requests")
+    print(f"  DP instances: 7 (each handling ~2 concurrent requests)")
+    print()
+
+    results = []
+    errors = []
+    start_time = time.perf_counter()
+    request_counter = [0]  # mutable counter for threads
+
+    def send_request(client: httpx.Client) -> dict:
+        req_id = request_counter[0]
+        request_counter[0] += 1
+        payload = {
+            "model": BASE_MODEL,
+            "messages": [
+                {"role": "user", "content": f"Write a creative haiku about number {req_id % 100}. Be brief."}
+            ],
+            "max_tokens": 128,
+            "temperature": 0.9,
+        }
+        req_start = time.perf_counter()
+        try:
+            resp = client.post(
+                f"{BASE_URL}/oai/api/v1/chat/completions",
+                json=payload,
+                headers={"X-API-Key": API_KEY},
+                timeout=120.0,
+            )
+            elapsed = time.perf_counter() - req_start
+            return {"id": req_id, "status": resp.status_code, "elapsed": elapsed, "ok": resp.status_code == 200}
+        except Exception as e:
+            elapsed = time.perf_counter() - req_start
+            return {"id": req_id, "status": 0, "elapsed": elapsed, "ok": False, "error": str(e)}
+
+    # Sustained load loop
+    with httpx.Client() as client:
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = []
+            # Keep submitting requests for the duration
+            while time.perf_counter() - start_time < duration_seconds:
+                # Maintain concurrency level
+                # Remove completed futures
+                done = [f for f in futures if f.done()]
+                for f in done:
+                    results.append(f.result())
+                    futures.remove(f)
+
+                # Submit new requests to maintain concurrency
+                while len(futures) < concurrency and (time.perf_counter() - start_time) < duration_seconds:
+                    futures.append(executor.submit(send_request, client))
+
+                time.sleep(0.05)  # Small sleep to avoid busy-waiting
+
+            # Wait for remaining futures
+            for f in futures:
+                results.append(f.result())
+
+    total_time = time.perf_counter() - start_time
+    successes = sum(1 for r in results if r["ok"])
+    failures = len(results) - successes
+    avg_latency = sum(r["elapsed"] for r in results) / max(len(results), 1)
+    p50 = sorted(r["elapsed"] for r in results)[len(results) // 2] if results else 0
+    p99 = sorted(r["elapsed"] for r in results)[int(len(results) * 0.99)] if results else 0
+    throughput = len(results) / total_time
+
+    print(f"  === Results ===")
+    print(f"  Total requests:  {len(results)}")
+    print(f"  Successes:       {successes}/{len(results)}")
+    print(f"  Failures:        {failures}")
+    print(f"  Duration:        {total_time:.1f}s")
+    print(f"  Throughput:      {throughput:.1f} req/s")
+    print(f"  Avg latency:     {avg_latency:.2f}s")
+    print(f"  P50 latency:     {p50:.2f}s")
+    print(f"  P99 latency:     {p99:.2f}s")
+    print()
+
+    # Check GPU utilization
+    print("  [Final] GPU utilization:")
+    for gpu in get_gpu_utilization():
+        status = "ACTIVE" if gpu["gpu_util_pct"] > 0 else ("LOADED" if gpu["memory_used_mib"] > 5000 else "idle")
+        print(f"    GPU {gpu['index']}: mem={gpu['memory_used_mib']}MiB  util={gpu['gpu_util_pct']}%  [{status}]")
+    print()
+
+    assert successes == len(results), f"{failures} requests failed"
+    print(f"  [PASS] Sustained load test: {throughput:.1f} req/s with {concurrency} concurrency")
+    print()
+    return True
+
+
+def main():
+    print()
+    print("TuFT Data Parallel Inference + Training Integration Test")
+    print("=" * 70)
+    print(f"  Server: {BASE_URL}")
+    print(f"  Model: {BASE_MODEL}")
+    print(f"  Config: data_parallel_size=7, tensor_parallel_size=1, fsdp_num_gpus=1")
+    print(f"  GPU layout: GPU 0 = training, GPU 1-7 = inference DP instances")
+    print()
+
+    all_pass = True
+
+    # Test 1: Concurrent inference
+    try:
+        test_concurrent_inference()
+    except Exception as e:
+        print(f"  [FAIL] {e}")
+        all_pass = False
+
+    # Test 2: Training
+    try:
+        test_training()
+    except Exception as e:
+        print(f"  [FAIL] {e}")
+        all_pass = False
+
+    # Test 3: Inference after training
+    try:
+        test_inference_after_training()
+    except Exception as e:
+        print(f"  [FAIL] {e}")
+        all_pass = False
+
+    # Test 3b: OAI API LoRA across all DP instances
+    try:
+        if not test_oai_lora_dp_routing():
+            all_pass = False
+    except Exception as e:
+        print(f"  [FAIL] {e}")
+        all_pass = False
+
+    # Test 4: Sustained load
+    try:
+        test_sustained_concurrent_load()
+    except Exception as e:
+        print(f"  [FAIL] {e}")
+        all_pass = False
+
+    # Summary
+    print("=" * 70)
+    if all_pass:
+        print("ALL TESTS PASSED - DP inference + training working correctly!")
+    else:
+        print("SOME TESTS FAILED - check output above")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lora_before_after.py
+++ b/tests/test_lora_before_after.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import os
 import sys
-import time
 from pathlib import Path
 
 import httpx
@@ -28,9 +27,11 @@ import tinker
 from tinker import types
 from transformers import AutoTokenizer
 
+
 # Add examples dir to path for dataset import
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "chat_sft"))
 from dataset import ChatDataset, conversation_to_datum, load_chat_dataset
+
 
 # Configuration (can be overridden via env vars)
 BASE_URL = os.getenv("TUFT_BASE_URL", "http://localhost:10610")
@@ -63,11 +64,13 @@ def pick_test_examples(train_dataset: ChatDataset, n: int = 3):
                 # Pick examples with medium-length answers (not too long, not too short)
                 content = asst_msg["content"]
                 if 50 < len(content) < 500:
-                    examples.append({
-                        "user_content": user_msg["content"],
-                        "expected_answer": content,
-                        "messages": messages,
-                    })
+                    examples.append(
+                        {
+                            "user_content": user_msg["content"],
+                            "expected_answer": content,
+                            "messages": messages,
+                        }
+                    )
                     if len(examples) >= n:
                         break
     return examples
@@ -93,9 +96,7 @@ def query_oai_api(model: str, user_content: str, max_tokens: int = 256) -> str:
         return data["choices"][0]["message"]["content"]
 
 
-def query_sdk_sample(
-    sampling_client, tokenizer, user_content: str, max_tokens: int = 256
-) -> str:
+def query_sdk_sample(sampling_client, tokenizer, user_content: str, max_tokens: int = 256) -> str:
     """Query via tinker SDK sampling."""
     messages = [{"role": "user", "content": user_content}]
     prompt_text = tokenizer.apply_chat_template(
@@ -138,9 +139,7 @@ def train_lora(service_client, tokenizer, train_dataset, test_examples):
             continue
 
         fb = training_client.forward_backward(datums, loss_fn="cross_entropy").result()
-        training_client.optim_step(
-            types.AdamParams(learning_rate=LEARNING_RATE)
-        ).result()
+        training_client.optim_step(types.AdamParams(learning_rate=LEARNING_RATE)).result()
 
         if step % 10 == 0 or step == NUM_STEPS - 1:
             # Compute loss
@@ -153,9 +152,7 @@ def train_lora(service_client, tokenizer, train_dataset, test_examples):
 
     # Save weights
     print("\n[Training] Saving weights for sampler...")
-    save_result = training_client.save_weights_for_sampler(
-        name="lora-before-after-test"
-    ).result()
+    save_result = training_client.save_weights_for_sampler(name="lora-before-after-test").result()
     print(f"  path={save_result.path}")
 
     return training_client, save_result.path
@@ -167,8 +164,8 @@ def main():
     print("=" * 70)
     print(f"  Server: {BASE_URL}")
     print(f"  Model: {BASE_MODEL}")
-    print(f"  This test trains a LoRA and compares outputs before/after training")
-    print(f"  using both the SDK sampling path and the OAI API path.")
+    print("  This test trains a LoRA and compares outputs before/after training")
+    print("  using both the SDK sampling path and the OAI API path.")
     print()
 
     # Setup
@@ -181,7 +178,7 @@ def main():
     test_examples = pick_test_examples(train_dataset, n=3)
     print(f"  Selected {len(test_examples)} test examples from training data:")
     for i, ex in enumerate(test_examples):
-        print(f"    Example {i+1}: Q='{ex['user_content'][:80]}...'")
+        print(f"    Example {i + 1}: Q='{ex['user_content'][:80]}...'")
         print(f"               A='{ex['expected_answer'][:80]}...'")
     print()
 
@@ -191,7 +188,7 @@ def main():
     for i, ex in enumerate(test_examples):
         resp = query_oai_api(BASE_MODEL, ex["user_content"], max_tokens=200)
         base_responses_oai.append(resp)
-        print(f"  Base OAI #{i+1}: '{resp[:120]}...'")
+        print(f"  Base OAI #{i + 1}: '{resp[:120]}...'")
     print()
 
     # Step 3: Query BASE model via SDK (create a base-model sampling session)
@@ -201,14 +198,12 @@ def main():
     for i, ex in enumerate(test_examples):
         resp = query_sdk_sample(base_sampling_client, tokenizer, ex["user_content"], max_tokens=200)
         base_responses_sdk.append(resp)
-        print(f"  Base SDK #{i+1}: '{resp[:120]}...'")
+        print(f"  Base SDK #{i + 1}: '{resp[:120]}...'")
     print()
 
     # Step 4: Train LoRA
     print("[4] Training LoRA adapter...")
-    training_client, lora_path = train_lora(
-        service_client, tokenizer, train_dataset, test_examples
-    )
+    training_client, lora_path = train_lora(service_client, tokenizer, train_dataset, test_examples)
     print()
 
     # Step 5: Query FINE-TUNED model via OAI API
@@ -217,7 +212,7 @@ def main():
     for i, ex in enumerate(test_examples):
         resp = query_oai_api(lora_path, ex["user_content"], max_tokens=200)
         ft_responses_oai.append(resp)
-        print(f"  LoRA OAI #{i+1}: '{resp[:120]}...'")
+        print(f"  LoRA OAI #{i + 1}: '{resp[:120]}...'")
     print()
 
     # Step 6: Query FINE-TUNED model via SDK
@@ -227,7 +222,7 @@ def main():
     for i, ex in enumerate(test_examples):
         resp = query_sdk_sample(lora_sampling_client, tokenizer, ex["user_content"], max_tokens=200)
         ft_responses_sdk.append(resp)
-        print(f"  LoRA SDK #{i+1}: '{resp[:120]}...'")
+        print(f"  LoRA SDK #{i + 1}: '{resp[:120]}...'")
     print()
 
     # Step 7: Compare and report
@@ -237,7 +232,7 @@ def main():
 
     all_different = True
     for i, ex in enumerate(test_examples):
-        print(f"\n--- Example {i+1} ---")
+        print(f"\n--- Example {i + 1} ---")
         print(f"  Question: {ex['user_content'][:100]}")
         print(f"  Expected (training data): {ex['expected_answer'][:100]}...")
         print()

--- a/tests/test_lora_before_after.py
+++ b/tests/test_lora_before_after.py
@@ -1,0 +1,274 @@
+"""Integration test: Verify LoRA fine-tuned model produces different outputs from the base model.
+
+This test:
+1. Picks a training example (user question + expected assistant answer)
+2. Queries the BASE model with the user question (before-training behavior)
+3. Trains a LoRA adapter on a focused dataset
+4. Queries the FINE-TUNED model with the same question (after-training behavior)
+5. Verifies both SDK (sampling_client.sample) and OAI API (/chat/completions) paths
+6. Shows the difference between base model output and fine-tuned output
+
+Run with:
+    pytest tests/test_lora_before_after.py -m integration -v
+
+Or directly:
+    python tests/test_lora_before_after.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import tinker
+from tinker import types
+from transformers import AutoTokenizer
+
+# Add examples dir to path for dataset import
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "chat_sft"))
+from dataset import ChatDataset, conversation_to_datum, load_chat_dataset
+
+# Configuration (can be overridden via env vars)
+BASE_URL = os.getenv("TUFT_BASE_URL", "http://localhost:10610")
+API_KEY = os.getenv("TUFT_API_KEY", "tml-tuft-dev-key")
+BASE_MODEL = os.getenv("TUFT_BASE_MODEL", "Qwen/Qwen3-4B-Thinking-2507")
+MODEL_PATH = os.getenv("TUFT_MODEL_PATH", "/mnt/workspace/shared/qwen/Qwen3-4B-Thinking-2507")
+
+# Mark all tests as integration (require running server + GPU)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.gpu,
+]
+
+# Training config - small focused training to see clear difference
+LORA_RANK = 16
+NUM_STEPS = 30
+BATCH_SIZE = 8
+LEARNING_RATE = 3e-4  # Slightly higher LR for faster convergence on small data
+MAX_LENGTH = 512
+
+
+def pick_test_examples(train_dataset: ChatDataset, n: int = 3):
+    """Pick training examples that have clear user->assistant patterns."""
+    examples = []
+    for messages in train_dataset.data[:100]:  # Search in first 100
+        if len(messages) >= 2:
+            user_msg = next((m for m in messages if m["role"] == "user"), None)
+            asst_msg = next((m for m in messages if m["role"] == "assistant"), None)
+            if user_msg and asst_msg:
+                # Pick examples with medium-length answers (not too long, not too short)
+                content = asst_msg["content"]
+                if 50 < len(content) < 500:
+                    examples.append({
+                        "user_content": user_msg["content"],
+                        "expected_answer": content,
+                        "messages": messages,
+                    })
+                    if len(examples) >= n:
+                        break
+    return examples
+
+
+def query_oai_api(model: str, user_content: str, max_tokens: int = 256) -> str:
+    """Query via OpenAI-compatible API."""
+    with httpx.Client() as client:
+        resp = client.post(
+            f"{BASE_URL}/oai/api/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": user_content}],
+                "max_tokens": max_tokens,
+                "temperature": 0.1,  # Low temp for deterministic comparison
+            },
+            headers={"X-API-Key": API_KEY},
+            timeout=120.0,
+        )
+        if resp.status_code != 200:
+            return f"[ERROR {resp.status_code}]: {resp.text[:200]}"
+        data = resp.json()
+        return data["choices"][0]["message"]["content"]
+
+
+def query_sdk_sample(
+    sampling_client, tokenizer, user_content: str, max_tokens: int = 256
+) -> str:
+    """Query via tinker SDK sampling."""
+    messages = [{"role": "user", "content": user_content}]
+    prompt_text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=False)
+
+    result = sampling_client.sample(
+        prompt=types.ModelInput.from_ints(prompt_tokens),
+        num_samples=1,
+        sampling_params=types.SamplingParams(max_tokens=max_tokens, temperature=0.1),
+    ).result()
+
+    return tokenizer.decode(result.sequences[0].tokens)
+
+
+def train_lora(service_client, tokenizer, train_dataset, test_examples):
+    """Train a LoRA adapter focused on the test examples' domain."""
+    print("\n[Training] Creating LoRA client...")
+    training_client = service_client.create_lora_training_client(
+        base_model=BASE_MODEL,
+        rank=LORA_RANK,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+    print(f"  rank={LORA_RANK}, steps={NUM_STEPS}, batch={BATCH_SIZE}, lr={LEARNING_RATE}")
+
+    # Train
+    print(f"\n[Training] Running {NUM_STEPS} steps...")
+    for step in range(NUM_STEPS):
+        batch = train_dataset.get_batch(BATCH_SIZE)
+        datums = []
+        for messages in batch:
+            try:
+                datums.append(conversation_to_datum(messages, tokenizer, MAX_LENGTH))
+            except ValueError:
+                continue
+        if not datums:
+            continue
+
+        fb = training_client.forward_backward(datums, loss_fn="cross_entropy").result()
+        training_client.optim_step(
+            types.AdamParams(learning_rate=LEARNING_RATE)
+        ).result()
+
+        if step % 10 == 0 or step == NUM_STEPS - 1:
+            # Compute loss
+            loss_outputs = fb.loss_fn_outputs
+            if loss_outputs:
+                logprobs_data = loss_outputs[0].get("logprobs")
+                if logprobs_data and hasattr(logprobs_data, "data"):
+                    avg_lp = sum(logprobs_data.data) / max(len(logprobs_data.data), 1)
+                    print(f"    step {step}: avg_logprob={avg_lp:.4f}")
+
+    # Save weights
+    print("\n[Training] Saving weights for sampler...")
+    save_result = training_client.save_weights_for_sampler(
+        name="lora-before-after-test"
+    ).result()
+    print(f"  path={save_result.path}")
+
+    return training_client, save_result.path
+
+
+def main():
+    print("=" * 70)
+    print("TEST: Base Model vs Fine-Tuned Model Output Comparison")
+    print("=" * 70)
+    print(f"  Server: {BASE_URL}")
+    print(f"  Model: {BASE_MODEL}")
+    print(f"  This test trains a LoRA and compares outputs before/after training")
+    print(f"  using both the SDK sampling path and the OAI API path.")
+    print()
+
+    # Setup
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    service_client = tinker.ServiceClient(base_url=BASE_URL, api_key=API_KEY)
+
+    # Load dataset and pick test examples
+    print("[1] Loading dataset and picking test examples...")
+    train_dataset, _ = load_chat_dataset("no_robots", seed=42)
+    test_examples = pick_test_examples(train_dataset, n=3)
+    print(f"  Selected {len(test_examples)} test examples from training data:")
+    for i, ex in enumerate(test_examples):
+        print(f"    Example {i+1}: Q='{ex['user_content'][:80]}...'")
+        print(f"               A='{ex['expected_answer'][:80]}...'")
+    print()
+
+    # Step 2: Query BASE model (before training) via OAI API
+    print("[2] Querying BASE model (before training)...")
+    base_responses_oai = []
+    for i, ex in enumerate(test_examples):
+        resp = query_oai_api(BASE_MODEL, ex["user_content"], max_tokens=200)
+        base_responses_oai.append(resp)
+        print(f"  Base OAI #{i+1}: '{resp[:120]}...'")
+    print()
+
+    # Step 3: Query BASE model via SDK (create a base-model sampling session)
+    print("[3] Querying BASE model via SDK...")
+    base_sampling_client = service_client.create_sampling_client(base_model=BASE_MODEL)
+    base_responses_sdk = []
+    for i, ex in enumerate(test_examples):
+        resp = query_sdk_sample(base_sampling_client, tokenizer, ex["user_content"], max_tokens=200)
+        base_responses_sdk.append(resp)
+        print(f"  Base SDK #{i+1}: '{resp[:120]}...'")
+    print()
+
+    # Step 4: Train LoRA
+    print("[4] Training LoRA adapter...")
+    training_client, lora_path = train_lora(
+        service_client, tokenizer, train_dataset, test_examples
+    )
+    print()
+
+    # Step 5: Query FINE-TUNED model via OAI API
+    print("[5] Querying FINE-TUNED model via OAI API...")
+    ft_responses_oai = []
+    for i, ex in enumerate(test_examples):
+        resp = query_oai_api(lora_path, ex["user_content"], max_tokens=200)
+        ft_responses_oai.append(resp)
+        print(f"  LoRA OAI #{i+1}: '{resp[:120]}...'")
+    print()
+
+    # Step 6: Query FINE-TUNED model via SDK
+    print("[6] Querying FINE-TUNED model via SDK...")
+    lora_sampling_client = service_client.create_sampling_client(model_path=lora_path)
+    ft_responses_sdk = []
+    for i, ex in enumerate(test_examples):
+        resp = query_sdk_sample(lora_sampling_client, tokenizer, ex["user_content"], max_tokens=200)
+        ft_responses_sdk.append(resp)
+        print(f"  LoRA SDK #{i+1}: '{resp[:120]}...'")
+    print()
+
+    # Step 7: Compare and report
+    print("=" * 70)
+    print("COMPARISON: Base Model vs Fine-Tuned Model")
+    print("=" * 70)
+
+    all_different = True
+    for i, ex in enumerate(test_examples):
+        print(f"\n--- Example {i+1} ---")
+        print(f"  Question: {ex['user_content'][:100]}")
+        print(f"  Expected (training data): {ex['expected_answer'][:100]}...")
+        print()
+        print(f"  [OAI API] Base model:      {base_responses_oai[i][:100]}...")
+        print(f"  [OAI API] Fine-tuned model: {ft_responses_oai[i][:100]}...")
+        oai_different = base_responses_oai[i][:50] != ft_responses_oai[i][:50]
+        print(f"  [OAI API] Different? {'YES ✓' if oai_different else 'NO (same output)'}")
+        print()
+        print(f"  [SDK]     Base model:      {base_responses_sdk[i][:100]}...")
+        print(f"  [SDK]     Fine-tuned model: {ft_responses_sdk[i][:100]}...")
+        sdk_different = base_responses_sdk[i][:50] != ft_responses_sdk[i][:50]
+        print(f"  [SDK]     Different? {'YES ✓' if sdk_different else 'NO (same output)'}")
+
+        if not oai_different and not sdk_different:
+            all_different = False
+
+    print()
+    print("=" * 70)
+    if all_different:
+        print("RESULT: ALL EXAMPLES show different outputs between base and fine-tuned model!")
+        print("        Both SDK and OAI API correctly serve the fine-tuned weights.")
+    else:
+        print("RESULT: Some examples show same output. Training may need more steps")
+        print("        or the model already knew the answer. Check details above.")
+    print("=" * 70)
+
+
+def test_lora_before_after():
+    """Pytest entry point for LoRA before/after comparison test."""
+    main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Enable multiple vLLM replicas (data_parallel_size) to serve the same base model across different GPUs, providing higher throughput for models that fit on a single GPU with memory to spare.

Key changes:
- ModelConfig: add data_parallel_size field (default 1)
- VLLMSamplingBackend: spawn N independent sampling actors with round-robin dispatch and per-replica LoRA state sync
- OAI router: load-balance chat completions across DP replicas
- base_backend: expose fsdp_index for port allocation

Tests:
- test_data_parallel.py: unit tests for DP dispatch and LoRA sync
- test_lora_before_after.py: verify LoRA adapter correctness