### PR TITLE
ci: fix docker release workflow and tighten GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
-          path: tuft-${{ github.run_id }}
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -56,9 +55,9 @@ jobs:
         id: push
         uses: docker/build-push-action@v4
         with:
-          context: tuft-${{ github.run_id }}
+          context: .
           push: true
-          file: tuft-${{ github.run_id }}/docker/Dockerfile
+          file: docker/Dockerfile
           shm-size: 128g
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -70,8 +69,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-      - name: Cleanup workspace
-        if: always()
-        run: |
-          sudo rm -rf tuft-${{ github.run_id }} 2>/dev/null

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/install-script.yml'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   test-install-script:
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,8 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
-  checks: write
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Two related CI hardening changes to `.github/workflows/`:

### 1. Fix the always-failing docker release workflow (`docker.yml`)
Every release-triggered run (v0.1.0 → v0.1.6) was marked **failed**, yet the GHCR package kept updating. Root cause: the build, push, and attestation steps all succeed — only the final `Cleanup workspace` step fails, because `sudo rm -rf … 2>/dev/null` exits 1 on the `self-hosted` runner (sudo isn't passwordless; the error is hidden by `2>/dev/null`), and the step's `bash -e` turns that into a job failure.

Fix (option discussed: drop the per-run dir entirely):
- Remove `path: tuft-${{ github.run_id }}` from checkout → use the default workspace, so `actions/checkout`'s built-in `clean: true` wipes the tree at the start of each run.
- Point the build at the default location: `context: .`, `file: docker/Dockerfile`.
- Delete the broken `Cleanup workspace` step. No more `sudo`, no more red ❌, no workspace accumulation.

### 2. Tighten `GITHUB_TOKEN` to least privilege
The repo's default workflow token is **write** (`default_workflow_permissions: write`), so workflows without an explicit block silently get read-write across all scopes — including fork-exposed ones.

| Workflow | Before | After |
|---|---|---|
| `unittest.yml` | contents:write, checks:write, pull-requests:write | **contents:read**, pull-requests:write |
| `checks.yml` | (none → write-all) | **contents:read** |
| `install-script.yml` | (none → write-all) | **contents:read** |
| `publish.yml` | build job (none → write-all) | top-level **contents:read** (publish job keeps `id-token:write`) |

Verification: walked each job's steps. Only `unittest.yml`'s ctrf reporter calls the API with the token — its `issue:` input posts a PR comment (needs pull-requests:write); `status-check` defaults to `false`, so checks:write was unused. No job writes repo contents, so `contents:read` covers checkout.

`docker.yml`'s permission block (contents:read, packages:write, attestations:write, id-token:write) is already minimal and unchanged.

## Notes / follow-ups (not in this PR)
- Recommend flipping the repo default to read: `gh api -X PUT repos/agentscope-ai/TuFT/actions/permissions/workflow -f default_workflow_permissions=read` (defense-in-depth; all workflows now have explicit blocks).
- `sphinx-doc.yml` keeps `contents:write` — only used by the gh-pages deploy step gated on push-to-main; could be split into build/deploy jobs later.
- Stale `tuft-<run_id>/` dirs from past runs still sit on the `GPU-1` runner and need a one-time manual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)