### PR TITLE
feat: support Qwen3.5 with verl 0.8.0 and flash-attn CUDA 13

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -255,10 +255,10 @@ jobs:
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 
-      - name: Test upgrade --from-source
+      - name: Test upgrade --from-source (uses local checkout)
         run: |
           export PATH="${TUFT_HOME}/bin:$PATH"
-          tuft upgrade --from-source
+          tuft upgrade --local-source "$GITHUB_WORKSPACE"
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -259,9 +259,10 @@ jobs:
         run: |
           export PATH="${TUFT_HOME}/bin:$PATH"
           # Exercise the real VCS clone+build+resolve path (not --local-source),
-          # pointed at this checkout's git so it validates the PR's own published
-          # metadata instead of upstream main.
-          export TUFT_GIT_URL="file://$GITHUB_WORKSPACE"
+          # pointed at this checkout's git. Pin the exact commit ($GITHUB_SHA):
+          # a bare file:// repo has no origin/HEAD, so uv cannot infer a default
+          # branch and fails without an explicit rev.
+          export TUFT_GIT_URL="file://$GITHUB_WORKSPACE@$GITHUB_SHA"
           tuft upgrade --from-source
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -187,7 +187,13 @@ jobs:
       - name: Test upgrade command (from PyPI)
         run: |
           export PATH="${TUFT_HOME}/bin:$PATH"
+          # Prove an installed wrapper refreshes a stale pin before resolving.
+          printf '%s\n' 'verl==0.8.0' > "${TUFT_HOME}/scripts/verl-git-override.txt"
+          export TUFT_VERL_OVERRIDE_URL="file://${GITHUB_WORKSPACE}/scripts/verl-git-override.txt"
           tuft upgrade
+          cmp scripts/verl-git-override.txt "${TUFT_HOME}/scripts/verl-git-override.txt"
+          "${TUFT_HOME}/venv/bin/python" -c \
+            "from importlib.metadata import version; assert version('tuft') == '0.1.8'"
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -255,10 +255,14 @@ jobs:
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 
-      - name: Test upgrade --from-source (uses local checkout)
+      - name: Test upgrade --from-source (real git path against this checkout)
         run: |
           export PATH="${TUFT_HOME}/bin:$PATH"
-          tuft upgrade --local-source "$GITHUB_WORKSPACE"
+          # Exercise the real VCS clone+build+resolve path (not --local-source),
+          # pointed at this checkout's git so it validates the PR's own published
+          # metadata instead of upstream main.
+          export TUFT_GIT_URL="file://$GITHUB_WORKSPACE"
+          tuft upgrade --from-source
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 

--- a/README.md
+++ b/README.md
@@ -252,13 +252,17 @@ We recommend using [uv](https://github.com/astral-sh/uv) for dependency manageme
 
 ### Install via PyPI
 
-You can also install TuFT directly from PyPI:
+Until Verl publishes a release containing its NumPy 2 fixes, PyPI installs
+must use TuFT's temporary override file:
 
 ```bash
-uv pip install tuft
+curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
+  -o /tmp/tuft-verl-git-override.txt
+uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
 
 # Install optional dependencies as needed
-uv pip install "tuft[dev,backend,persistence,examples]"
+uv pip install --override /tmp/tuft-verl-git-override.txt \
+  "tuft[dev,backend,persistence,examples]>=0.1.8"
 ```
 
 ### Run the server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY ./scripts ./scripts
 RUN bash ./scripts/install.sh --local-source /workspace \
     && . $HOME/.local/bin/env \
     && . /root/.tuft/venv/bin/activate \
-    && uv pip install .[dev]
+    && uv pip install .[dev] --override scripts/verl-git-override.txt
 
 ENTRYPOINT ["/bin/bash", "-c", "source ${VIRTUAL_ENV}/bin/activate && exec \"$@\"", "--"]
 CMD ["bash"]

--- a/docs/sphinx_doc/source/getting-started/installation.md
+++ b/docs/sphinx_doc/source/getting-started/installation.md
@@ -69,13 +69,17 @@ We recommend using [uv](https://github.com/astral-sh/uv) for dependency manageme
 
 ## Install via PyPI
 
-You can also install TuFT directly from PyPI:
+Until Verl publishes a release containing its NumPy 2 fixes, PyPI installs
+must use TuFT's temporary override file:
 
 ```bash
-uv pip install tuft
+curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
+  -o /tmp/tuft-verl-git-override.txt
+uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
 
 # Install optional dependencies as needed
-uv pip install "tuft[dev,backend,persistence]"
+uv pip install --override /tmp/tuft-verl-git-override.txt \
+  "tuft[dev,backend,persistence]>=0.1.8"
 ```
 
 ## Use the Pre-built Docker Image

--- a/docs/sphinx_doc/source/user-guide/persistence.md
+++ b/docs/sphinx_doc/source/user-guide/persistence.md
@@ -38,7 +38,9 @@ This document is organized into two parts:
 ### Install optional dependency
 
 ```bash
-uv pip install "tuft[persistence]"
+curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
+  -o /tmp/tuft-verl-git-override.txt
+uv pip install --override /tmp/tuft-verl-git-override.txt "tuft[persistence]>=0.1.8"
 ```
 
 ### Enable persistence

--- a/docs/sphinx_doc/source_zh/getting-started/installation.md
+++ b/docs/sphinx_doc/source_zh/getting-started/installation.md
@@ -69,13 +69,17 @@ tuft
 
 ## 通过 PyPI 安装
 
-您也可以直接从 PyPI 安装 TuFT：
+在 Verl 发布包含 NumPy 2 修复的版本之前，通过 PyPI 安装时必须使用
+TuFT 提供的临时 override 文件：
 
 ```bash
-uv pip install tuft
+curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
+  -o /tmp/tuft-verl-git-override.txt
+uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
 
 # 根据需要安装可选依赖
-uv pip install "tuft[dev,backend,persistence]"
+uv pip install --override /tmp/tuft-verl-git-override.txt \
+  "tuft[dev,backend,persistence]>=0.1.8"
 ```
 
 ## 使用预构建的 Docker 镜像

--- a/docs/sphinx_doc/source_zh/user-guide/persistence.md
+++ b/docs/sphinx_doc/source_zh/user-guide/persistence.md
@@ -38,7 +38,9 @@ TuFT 支持**可选的持久化**来保存服务器状态。启用后，TuFT 可
 ### 安装可选依赖
 
 ```bash
-uv pip install "tuft[persistence]"
+curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
+  -o /tmp/tuft-verl-git-override.txt
+uv pip install --override /tmp/tuft-verl-git-override.txt "tuft[persistence]>=0.1.8"
 ```
 
 ### 启用持久化

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,16 +125,18 @@ ruff = ["--fix"]
 [tool.nbqa.exclude]
 ruff = "^(\\.venv|tinker)/"
 
-# Override upstream constraints that lag behind our requirements:
-# - Qwen3.5 needs transformers>=5.2 for architecture registration.
-# - vLLM 0.23+ for Qwen3.5 support; verl 0.8.0 supports vLLM>=0.8.2.
-# - numpy>=2 needed by vllm/opencv-python-headless.
 [tool.uv]
+# Force numpy>=2: the latest *released* verl (0.8.0) still hard-pins
+# numpy<2.0.0, while vLLM (numpy-2 ABI) needs numpy>=2; without this override
+# uv silently installs numpy 1.x and breaks vLLM at runtime.
+# verl PR #6551 (merged to verl main 2026-06-18, commit 14574ec) relaxes this
+# to numpy>=2.0.0. Once verl publishes a release >0.8.0 that includes it, bump
+# verl>=<release> in [project.dependencies] and delete this override.
+# transformers/verl/vllm need no override: [project.dependencies] + trinity-rft
+# 0.6.0 (transformers>=5.12.1, verl>=0.7.1, vllm>=0.19.1,<=0.23.0) already
+# resolve them correctly.
 override-dependencies = [
-    "transformers>=5.2.0,<6.0.0",
-    "vllm>=0.16.0",
     "numpy>=2.0.0",
-    "verl>=0.8.0",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ ruff = ["--fix"]
 ruff = "^(\\.venv|tinker)/"
 
 [tool.uv]
+# Canonical rationale and removal procedure: scripts/verl-git-override.txt.
 # Force verl to the #6551 commit (numpy>=2 + vLLM/nccl runtime fixes). A normal
 # direct requirement can't satisfy verl>=0.8,<0.9 (the commit reports 0.9.0.dev0);
 # an override replaces the constraint. Covers project-mode installs (uv pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.125.0",
     "httpx>=0.28.1",
-    "numpy",
+    "numpy>=2.0.0",
     "tinker>=0.18.2",
     "protobuf>=4.21.0",
     "typer>=0.20.1",
@@ -30,8 +30,19 @@ dependencies = [
     "torch>=2.0.0",
     "peft>=0.18.0",
     "tensordict>=0.5.0",
-    "verl>=0.8.0",
-    "trinity-rft[vllm]>=0.5.2; sys_platform == 'linux'",
+    # verl pinned to the #6551 merge commit: the latest *released* verl (0.8.0)
+    # hard-pins numpy<2.0.0, which conflicts with opencv-python-headless (a vLLM
+    # dep) that requires numpy>=2 on py3.9+, making a wheel/git install
+    # unsatisfiable. #6551 (merged to verl main 2026-06-18) relaxes verl to
+    # numpy>=2.0.0. When verl publishes a release containing it, swap this to a
+    # normal spec, e.g. "verl>=<release>,<0.9". NOTE: a direct git URL cannot be
+    # uploaded to PyPI (twine rejects direct references); TuFT installs from
+    # source / via scripts/install.sh, so this is acceptable until then.
+    "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0",
+    # Explicit vLLM cap matching trinity-rft 0.6's tested range (Qwen3.5 needs
+    # >=0.19.1; trinity caps <=0.23.0) so the published metadata is unambiguous.
+    "vllm>=0.19.1,<=0.23.0; sys_platform == 'linux'",
+    "trinity-rft[vllm]>=0.6.0; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -125,22 +136,15 @@ ruff = ["--fix"]
 [tool.nbqa.exclude]
 ruff = "^(\\.venv|tinker)/"
 
-[tool.uv]
-# Force numpy>=2: the latest *released* verl (0.8.0) still hard-pins
-# numpy<2.0.0, while vLLM (numpy-2 ABI) needs numpy>=2; without this override
-# uv silently installs numpy 1.x and breaks vLLM at runtime.
-# verl PR #6551 (merged to verl main 2026-06-18, commit 14574ec) relaxes this
-# to numpy>=2.0.0. Once verl publishes a release >0.8.0 that includes it, bump
-# verl>=<release> in [project.dependencies] and delete this override.
-# transformers/verl/vllm need no override: [project.dependencies] + trinity-rft
-# 0.6.0 (transformers>=5.12.1, verl>=0.7.1, vllm>=0.19.1,<=0.23.0) already
-# resolve them correctly.
-override-dependencies = [
-    "numpy>=2.0.0",
-]
-
 [tool.uv.extra-build-dependencies]
 flash-attn = ["torch", "numpy"]
+
+# Allow the verl direct git reference in [project.dependencies] (see the note
+# there). Hatchling requires this to build a package that carries a direct URL
+# dependency; drop it together with the git pin once verl publishes a release
+# containing #6551.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [build-system]
 requires = ["hatchling", "setuptools>=65", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuft"
-version = "0.1.7"
+version = "0.1.8"
 description = "A multi-tenant fine-tuning platform for LLMs with Tinker-compatible API"
 authors = [
     { name = "TuFT Developers", email = "tuft@list.alibaba-inc.com" }
@@ -140,7 +140,9 @@ ruff = "^(\\.venv|tinker)/"
 # an override replaces the constraint. Covers project-mode installs (uv pip
 # install -e . / . / .[dev] / --local-source). install.sh and docker pass the
 # same pin via --override scripts/verl-git-override.txt for registry/git installs.
-# Remove both once verl publishes a release containing #6551.
+# Once verl publishes a release containing #6551, remove this project override
+# and leave scripts/verl-git-override.txt present but comment-only so installed
+# wrappers refresh away the temporary pin.
 override-dependencies = [
     "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.125.0",
     "httpx>=0.28.1",
-    "numpy<2.0.0",
+    "numpy",
     "tinker>=0.18.2",
     "protobuf>=4.21.0",
     "typer>=0.20.1",
     "uvicorn[standard]>=0.38.0",
     "omegaconf>=2.3.0",
     "ray>=2.50.0",
-    "transformers>=4.57.3,<5.0.0",
+    "transformers>=5.2.0,<6.0.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
@@ -30,8 +30,8 @@ dependencies = [
     "torch>=2.0.0",
     "peft>=0.18.0",
     "tensordict>=0.5.0",
-    "verl",
-    "trinity-rft[vllm]>=0.4.1; sys_platform == 'linux'",
+    "verl>=0.8.0",
+    "trinity-rft[vllm]>=0.5.2; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -51,7 +51,7 @@ dev = [
 ]
 backend = [
     "datasets>=4.0.0",
-    "huggingface-hub>=0.20.0,<1.0"
+    "huggingface-hub>=1.3.0,<2.0"
 ]
 persistence = [
     "redis>=5.0.0",
@@ -124,6 +124,18 @@ ruff = ["--fix"]
 
 [tool.nbqa.exclude]
 ruff = "^(\\.venv|tinker)/"
+
+# Override upstream constraints that lag behind our requirements:
+# - Qwen3.5 needs transformers>=5.2 for architecture registration.
+# - vLLM 0.23+ for Qwen3.5 support; verl 0.8.0 supports vLLM>=0.8.2.
+# - numpy>=2 needed by vllm/opencv-python-headless.
+[tool.uv]
+override-dependencies = [
+    "transformers>=5.2.0,<6.0.0",
+    "vllm>=0.16.0",
+    "numpy>=2.0.0",
+    "verl>=0.8.0",
+]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = ["torch", "numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,13 @@ dependencies = [
     "torch>=2.0.0",
     "peft>=0.18.0",
     "tensordict>=0.5.0",
-    # verl pinned to the #6551 merge commit: the latest *released* verl (0.8.0)
-    # hard-pins numpy<2.0.0, which conflicts with opencv-python-headless (a vLLM
-    # dep) that requires numpy>=2 on py3.9+, making a wheel/git install
-    # unsatisfiable. #6551 (merged to verl main 2026-06-18) relaxes verl to
-    # numpy>=2.0.0. When verl publishes a release containing it, swap this to a
-    # normal spec, e.g. "verl>=<release>,<0.9". NOTE: a direct git URL cannot be
-    # uploaded to PyPI (twine rejects direct references); TuFT installs from
-    # source / via scripts/install.sh, so this is acceptable until then.
-    "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0",
+    # Normal (registry-clean, publishable) metadata. The only released verl
+    # (0.8.0) hard-pins numpy<2.0.0, which conflicts with opencv (a vLLM dep,
+    # numpy>=2); verl #6551 (merged to main 2026-06-18) fixes this but is not yet
+    # released. We force the fixed commit via a uv override (see [tool.uv] below
+    # and scripts/verl-git-override.txt) rather than a direct URL here, so the
+    # published metadata stays clean and the <0.9 cap is honored.
+    "verl>=0.8.0,<0.9",
     # Explicit vLLM cap matching trinity-rft 0.6's tested range (Qwen3.5 needs
     # >=0.19.1; trinity caps <=0.23.0) so the published metadata is unambiguous.
     "vllm>=0.19.1,<=0.23.0; sys_platform == 'linux'",
@@ -136,15 +134,19 @@ ruff = ["--fix"]
 [tool.nbqa.exclude]
 ruff = "^(\\.venv|tinker)/"
 
+[tool.uv]
+# Force verl to the #6551 commit (numpy>=2 + vLLM/nccl runtime fixes). A normal
+# direct requirement can't satisfy verl>=0.8,<0.9 (the commit reports 0.9.0.dev0);
+# an override replaces the constraint. Covers project-mode installs (uv pip
+# install -e . / . / .[dev] / --local-source). install.sh and docker pass the
+# same pin via --override scripts/verl-git-override.txt for registry/git installs.
+# Remove both once verl publishes a release containing #6551.
+override-dependencies = [
+    "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0",
+]
+
 [tool.uv.extra-build-dependencies]
 flash-attn = ["torch", "numpy"]
-
-# Allow the verl direct git reference in [project.dependencies] (see the note
-# there). Hatchling requires this to build a package that carries a direct URL
-# dependency; drop it together with the git pin once verl publishes a release
-# containing #6551.
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [build-system]
 requires = ["hatchling", "setuptools>=65", "wheel"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ TUFT_HOME="${TUFT_HOME:-$HOME/.tuft}"
 TUFT_BIN="$TUFT_HOME/bin"
 TUFT_VENV="$TUFT_HOME/venv"
 PYTHON_VERSION="3.12"
-TUFT_PYPI_PACKAGE="tuft"
+TUFT_PYPI_REQUIREMENT="${TUFT_PYPI_REQUIREMENT:-tuft[backend,persistence]>=0.1.8}"
 TUFT_GIT_REPO="https://github.com/agentscope-ai/tuft.git"
 INSTALL_FROM_SOURCE=false
 LOCAL_SOURCE_PATH=""
@@ -70,6 +70,7 @@ parse_args() {
                 echo ""
                 echo "Environment Variables:"
                 echo "  TUFT_HOME             Installation directory (default: ~/.tuft)"
+                echo "  TUFT_PYPI_REQUIREMENT Override the default PyPI requirement"
                 exit 0
                 ;;
             *)
@@ -190,21 +191,21 @@ install_tuft() {
     # Determine package source
     if [ -n "$LOCAL_SOURCE_PATH" ]; then
         print_step "Installing from local source: $LOCAL_SOURCE_PATH"
-        PACKAGE_SPEC="$LOCAL_SOURCE_PATH"
+        PACKAGE_SPEC="${LOCAL_SOURCE_PATH}[backend,persistence]"
     elif [ "$INSTALL_FROM_SOURCE" = true ]; then
         print_step "Installing from GitHub: $TUFT_GIT_REPO"
-        PACKAGE_SPEC="git+${TUFT_GIT_REPO}"
+        PACKAGE_SPEC="git+${TUFT_GIT_REPO}#egg=tuft[backend,persistence]"
     else
-        print_step "Installing from PyPI: $TUFT_PYPI_PACKAGE"
-        PACKAGE_SPEC="$TUFT_PYPI_PACKAGE"
+        print_step "Installing from PyPI: $TUFT_PYPI_REQUIREMENT"
+        PACKAGE_SPEC="$TUFT_PYPI_REQUIREMENT"
     fi
 
     # Ensure the verl override file (pins verl to the #6551 commit) exists, then
     # install with it so registry/git resolves satisfy verl>=0.8,<0.9.
     setup_verl_override
 
-    # Install tuft with all extras (backend, persistence)
-    uv pip install --python "$TUFT_VENV/bin/python" --override "$VERL_OVERRIDE_FILE" "${PACKAGE_SPEC}[backend,persistence]"
+    # PACKAGE_SPEC already includes the backend and persistence extras.
+    uv pip install --python "$TUFT_VENV/bin/python" --override "$VERL_OVERRIDE_FILE" "$PACKAGE_SPEC"
 
     print_success "TuFT installed successfully"
 }
@@ -216,10 +217,19 @@ setup_verl_override() {
     mkdir -p "$(dirname "$VERL_OVERRIDE_FILE")"
     if [ -n "$LOCAL_SOURCE_PATH" ] && [ -f "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" ]; then
         cp "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" "$VERL_OVERRIDE_FILE"
-    elif ! curl -fsSL "$VERL_OVERRIDE_URL" -o "$VERL_OVERRIDE_FILE" 2>/dev/null; then
+        return
+    fi
+
+    local tmp_file="${VERL_OVERRIDE_FILE}.tmp"
+    if curl -fsSL "$VERL_OVERRIDE_URL" -o "$tmp_file" 2>/dev/null; then
+        mv "$tmp_file" "$VERL_OVERRIDE_FILE"
+    else
+        rm -f "$tmp_file"
         # Offline / pre-merge fallback. Keep in sync with pyproject [tool.uv]
         # override-dependencies and scripts/verl-git-override.txt.
-        printf '%s\n' "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0" > "$VERL_OVERRIDE_FILE"
+        if [ ! -f "$VERL_OVERRIDE_FILE" ]; then
+            printf '%s\n' "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0" > "$VERL_OVERRIDE_FILE"
+        fi
     fi
 }
 
@@ -278,6 +288,9 @@ set -e
 TUFT_HOME="${TUFT_HOME:-$HOME/.tuft}"
 TUFT_VENV="$TUFT_HOME/venv"
 TUFT_PYTHON="$TUFT_VENV/bin/python"
+TUFT_PYPI_REQUIREMENT="${TUFT_PYPI_REQUIREMENT:-tuft[backend,persistence]>=0.1.8}"
+VERL_OVERRIDE_URL="${TUFT_VERL_OVERRIDE_URL:-https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt}"
+VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
 
 # Verify installation
 if [ ! -f "$TUFT_PYTHON" ]; then
@@ -286,6 +299,27 @@ if [ ! -f "$TUFT_PYTHON" ]; then
     echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/install.sh)"'
     exit 1
 fi
+
+# Atomically refresh the release-channel override before upgrades. Keep the
+# remote file at this stable URL after the workaround is removed (it can become
+# comment-only), so old wrappers stop applying the pin instead of retaining it.
+refresh_verl_override() {
+    mkdir -p "$(dirname "$VERL_OVERRIDE_FILE")"
+    local tmp_file="${VERL_OVERRIDE_FILE}.tmp"
+    if curl -fsSL "$VERL_OVERRIDE_URL" -o "$tmp_file" 2>/dev/null; then
+        mv "$tmp_file" "$VERL_OVERRIDE_FILE"
+        return
+    fi
+
+    rm -f "$tmp_file"
+    if [ -f "$VERL_OVERRIDE_FILE" ]; then
+        echo "Warning: could not refresh the Verl override; using the existing file."
+        return
+    fi
+
+    echo "Error: Verl override is unavailable. Re-run the TuFT installer."
+    return 1
+}
 
 # Handle commands
 case "${1:-}" in
@@ -327,9 +361,15 @@ case "${1:-}" in
         # verl is pinned to the #6551 commit via a uv override file placed at
         # install time (scripts/verl-git-override.txt). Use --override (not a
         # direct requirement): the commit reports 0.9.0.dev0, which a normal
-        # requirement can't satisfy against verl>=0.8,<0.9. Remove once verl
-        # publishes a release containing #6551.
-        VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
+        # requirement can't satisfy against verl>=0.8,<0.9. Once verl publishes
+        # a release containing #6551, keep the remote file but make it
+        # comment-only so existing wrappers refresh away the temporary pin.
+        LOCAL_VERL_OVERRIDE="$UPGRADE_LOCAL_SOURCE/scripts/verl-git-override.txt"
+        if [ -n "$UPGRADE_LOCAL_SOURCE" ] && [ -f "$LOCAL_VERL_OVERRIDE" ]; then
+            cp "$LOCAL_VERL_OVERRIDE" "$VERL_OVERRIDE_FILE"
+        else
+            refresh_verl_override
+        fi
         if [ -n "$UPGRADE_LOCAL_SOURCE" ]; then
             echo "Upgrading from local source: $UPGRADE_LOCAL_SOURCE"
             uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
@@ -341,7 +381,7 @@ case "${1:-}" in
             echo "Upgrading from Git: git+${TUFT_GIT_URL}"
             uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
         else
-            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "tuft[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "$TUFT_PYPI_REQUIREMENT"
         fi
 
         # Also update flash-attn
@@ -397,6 +437,8 @@ case "${1:-}" in
         echo "  TUFT_PORT            Default port for launch command"
         echo "  TUFT_CHECKPOINT_DIR  Default checkpoint directory"
         echo "  TUFT_LOG_LEVEL       Default log level"
+        echo "  TUFT_PYPI_REQUIREMENT Override the PyPI package requirement"
+        echo "  TUFT_VERL_OVERRIDE_URL Override the release-channel Verl override URL"
         echo ""
         echo "Examples:"
         echo "  tuft launch --config tuft_config.yaml"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,8 +236,9 @@ setup_verl_override() {
 # URL for the flash-attn installation script
 FLASH_ATTN_SCRIPT_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/install_flash_attn.py"
 
-# uv override file that pins verl to the #6551 commit (numpy>=2 + runtime fixes);
-# see scripts/verl-git-override.txt. Passed via --override on every install path.
+# uv override file that pins verl to the #6551 commit (numpy>=2 + runtime fixes).
+# scripts/verl-git-override.txt is the canonical decision record and removal
+# procedure. Pass it via --override on every supported install path.
 VERL_OVERRIDE_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt"
 VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -301,18 +301,25 @@ case "${1:-}" in
         done
 
         echo "Upgrading TuFT..."
+        # verl is pinned to the #6551 git commit in pyproject (see the note there).
+        # uv only honors a URL dependency when it is a DIRECT requirement, not when
+        # it arrives transitively via a registry/git package, so pass it explicitly
+        # on the registry (PyPI) and git upgrade paths. The local-source path builds
+        # tuft as a project and needs no extra arg. Remove this together with the
+        # pyproject git pin once verl publishes a release containing #6551.
+        TUFT_VERL_GIT="verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0"
         if [ -n "$UPGRADE_LOCAL_SOURCE" ]; then
             echo "Upgrading from local source: $UPGRADE_LOCAL_SOURCE"
             uv pip install --python "$TUFT_PYTHON" --upgrade "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
         elif [ "$UPGRADE_FROM_SOURCE" = true ]; then
             # Repo is overridable (default: upstream main) so CI / advanced users
             # can exercise the real VCS clone+build+resolve path against a
-            # specific checkout, e.g. TUFT_GIT_URL="file://$GITHUB_WORKSPACE".
+            # specific checkout, e.g. TUFT_GIT_URL="file://$GITHUB_WORKSPACE@$GITHUB_SHA".
             TUFT_GIT_URL="${TUFT_GIT_URL:-https://github.com/agentscope-ai/tuft.git}"
             echo "Upgrading from Git: git+${TUFT_GIT_URL}"
-            uv pip install --python "$TUFT_PYTHON" --upgrade "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]" "$TUFT_VERL_GIT"
         else
-            uv pip install --python "$TUFT_PYTHON" --upgrade "tuft[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "tuft[backend,persistence]" "$TUFT_VERL_GIT"
         fi
 
         # Also update flash-attn

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -305,8 +305,12 @@ case "${1:-}" in
             echo "Upgrading from local source: $UPGRADE_LOCAL_SOURCE"
             uv pip install --python "$TUFT_PYTHON" --upgrade "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
         elif [ "$UPGRADE_FROM_SOURCE" = true ]; then
-            echo "Upgrading from GitHub..."
-            uv pip install --python "$TUFT_PYTHON" --upgrade "git+https://github.com/agentscope-ai/tuft.git#egg=tuft[backend,persistence]"
+            # Repo is overridable (default: upstream main) so CI / advanced users
+            # can exercise the real VCS clone+build+resolve path against a
+            # specific checkout, e.g. TUFT_GIT_URL="file://$GITHUB_WORKSPACE".
+            TUFT_GIT_URL="${TUFT_GIT_URL:-https://github.com/agentscope-ai/tuft.git}"
+            echo "Upgrading from Git: git+${TUFT_GIT_URL}"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
         else
             uv pip install --python "$TUFT_PYTHON" --upgrade "tuft[backend,persistence]"
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,14 +199,37 @@ install_tuft() {
         PACKAGE_SPEC="$TUFT_PYPI_PACKAGE"
     fi
 
+    # Ensure the verl override file (pins verl to the #6551 commit) exists, then
+    # install with it so registry/git resolves satisfy verl>=0.8,<0.9.
+    setup_verl_override
+
     # Install tuft with all extras (backend, persistence)
-    uv pip install --python "$TUFT_VENV/bin/python" "${PACKAGE_SPEC}[backend,persistence]"
+    uv pip install --python "$TUFT_VENV/bin/python" --override "$VERL_OVERRIDE_FILE" "${PACKAGE_SPEC}[backend,persistence]"
 
     print_success "TuFT installed successfully"
 }
 
+# Ensure the uv override file pinning verl to the #6551 commit exists at
+# $VERL_OVERRIDE_FILE (prefer the bundled file, else download, else write it
+# inline). See scripts/verl-git-override.txt for the rationale.
+setup_verl_override() {
+    mkdir -p "$(dirname "$VERL_OVERRIDE_FILE")"
+    if [ -n "$LOCAL_SOURCE_PATH" ] && [ -f "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" ]; then
+        cp "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" "$VERL_OVERRIDE_FILE"
+    elif ! curl -fsSL "$VERL_OVERRIDE_URL" -o "$VERL_OVERRIDE_FILE" 2>/dev/null; then
+        # Offline / pre-merge fallback. Keep in sync with pyproject [tool.uv]
+        # override-dependencies and scripts/verl-git-override.txt.
+        printf '%s\n' "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0" > "$VERL_OVERRIDE_FILE"
+    fi
+}
+
 # URL for the flash-attn installation script
 FLASH_ATTN_SCRIPT_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/install_flash_attn.py"
+
+# uv override file that pins verl to the #6551 commit (numpy>=2 + runtime fixes);
+# see scripts/verl-git-override.txt. Passed via --override on every install path.
+VERL_OVERRIDE_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt"
+VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
 
 # Install flash-attn from precompiled wheels (avoids lengthy compilation)
 # Also stores the script locally for later use by install-backend command
@@ -301,25 +324,24 @@ case "${1:-}" in
         done
 
         echo "Upgrading TuFT..."
-        # verl is pinned to the #6551 git commit in pyproject (see the note there).
-        # uv only honors a URL dependency when it is a DIRECT requirement, not when
-        # it arrives transitively via a registry/git package, so pass it explicitly
-        # on the registry (PyPI) and git upgrade paths. The local-source path builds
-        # tuft as a project and needs no extra arg. Remove this together with the
-        # pyproject git pin once verl publishes a release containing #6551.
-        TUFT_VERL_GIT="verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0"
+        # verl is pinned to the #6551 commit via a uv override file placed at
+        # install time (scripts/verl-git-override.txt). Use --override (not a
+        # direct requirement): the commit reports 0.9.0.dev0, which a normal
+        # requirement can't satisfy against verl>=0.8,<0.9. Remove once verl
+        # publishes a release containing #6551.
+        VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
         if [ -n "$UPGRADE_LOCAL_SOURCE" ]; then
             echo "Upgrading from local source: $UPGRADE_LOCAL_SOURCE"
-            uv pip install --python "$TUFT_PYTHON" --upgrade "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
         elif [ "$UPGRADE_FROM_SOURCE" = true ]; then
             # Repo is overridable (default: upstream main) so CI / advanced users
             # can exercise the real VCS clone+build+resolve path against a
             # specific checkout, e.g. TUFT_GIT_URL="file://$GITHUB_WORKSPACE@$GITHUB_SHA".
             TUFT_GIT_URL="${TUFT_GIT_URL:-https://github.com/agentscope-ai/tuft.git}"
             echo "Upgrading from Git: git+${TUFT_GIT_URL}"
-            uv pip install --python "$TUFT_PYTHON" --upgrade "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]" "$TUFT_VERL_GIT"
+            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
         else
-            uv pip install --python "$TUFT_PYTHON" --upgrade "tuft[backend,persistence]" "$TUFT_VERL_GIT"
+            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "tuft[backend,persistence]"
         fi
 
         # Also update flash-attn

--- a/scripts/install_flash_attn.py
+++ b/scripts/install_flash_attn.py
@@ -6,7 +6,9 @@ import sys
 import torch
 
 
-FLASH_VERSION = "2.8.3"
+# cu12 wheels are hosted on the aliyun mirror (2.8.3 is NOT published there ->
+# 403); cu13 uses the community GitHub 2.8.3 build. Keep per-CUDA versions.
+FLASH_VERSIONS = {"12": "2.8.1", "13": "2.8.3"}
 
 # Get torch version
 TORCH_VERSION_RAW = torch.__version__
@@ -32,9 +34,10 @@ if IS_ROCM:
 else:
     torch_cuda_version = torch.version.cuda  # type: ignore[attr-defined]
     cuda_major = torch_cuda_version.split(".")[0] if torch_cuda_version else None
-    if cuda_major not in ("12", "13"):
+    if cuda_major not in FLASH_VERSIONS:
         print(f"Only CUDA 12/13 wheels are hosted for flash-attn. Got CUDA {cuda_major}.")
         sys.exit(1)
+    FLASH_VERSION = FLASH_VERSIONS[cuda_major]
     # CUDA 13 wheels use "cu13" tag; CUDA 12 uses "cu12"
     cuda_version = cuda_major
     wheel_filename = (

--- a/scripts/install_flash_attn.py
+++ b/scripts/install_flash_attn.py
@@ -46,13 +46,31 @@ else:
     )
 
 if cuda_major == "13":
-    # CUDA 13 community wheels hosted on GitHub
+    # CUDA 13 wheels come from a third-party community GitHub release that only
+    # publishes ONE build tuple. Refuse to construct a URL that would 404, and
+    # pin a SHA-256 so we never install an unverified third-party artifact.
+    # (key: python_version, torch_version, platform_name, cxx11_abi -> sha256)
+    CU13_WHEELS = {
+        ("cp312", "2.11", "linux_x86_64", "TRUE"): (
+            "eea423825f3e12818b98b2078e2cb5ce6fe6b73d22612316d2a55fad4701938f"
+        ),
+    }
+    cu13_key = (python_version, torch_version, platform_name, cxx11_abi)
+    expected_sha256 = CU13_WHEELS.get(cu13_key)
+    if expected_sha256 is None:
+        print(
+            f"No hosted CUDA 13 flash-attn {FLASH_VERSION} wheel for {cu13_key}. "
+            "Only (cp312, torch 2.11, linux_x86_64, cxx11abi=TRUE) is available; "
+            "build flash-attn from source or use a matching interpreter/torch."
+        )
+        sys.exit(1)
     wheel_url = (
         "https://github.com/adithyaxx/flash-attention/releases/download"
         f"/v{FLASH_VERSION}/flash_attn-{FLASH_VERSION}%2Bcu{cuda_version}torch{torch_version}"
         f"cxx11abi{cxx11_abi}-{python_version}-{python_version}-{platform_name}.whl"
     )
 else:
+    expected_sha256 = None
     wheel_url = (
         "https://dail-wlcb.oss-cn-wulanchabu.aliyuncs.com"
         f"/AgentScope/download/flash-attn/{FLASH_VERSION}/{wheel_filename}"
@@ -69,6 +87,26 @@ if os.path.exists(local_path):
     os.remove(local_path)
 
 subprocess.run(["wget", wheel_url, "-O", local_path], check=True)
+
+# Verify the download against the pinned SHA-256 for third-party (CUDA 13)
+# wheels before installing, so a tampered/incorrect artifact never runs.
+if expected_sha256 is not None:
+    import hashlib
+
+    h = hashlib.sha256()
+    with open(local_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    actual_sha256 = h.hexdigest()
+    if actual_sha256 != expected_sha256:
+        print(
+            f"SHA-256 mismatch for {local_path}: "
+            f"expected {expected_sha256}, got {actual_sha256}. Aborting."
+        )
+        os.remove(local_path)
+        sys.exit(3)
+    print(f"SHA-256 verified: {actual_sha256}")
+
 subprocess.run(["uv", "pip", "install", "--python", sys.executable, local_path], check=True)
 
 # Try to import flash_attn

--- a/scripts/install_flash_attn.py
+++ b/scripts/install_flash_attn.py
@@ -6,7 +6,7 @@ import sys
 import torch
 
 
-FLASH_VERSION = "2.8.1"
+FLASH_VERSION = "2.8.3"
 
 # Get torch version
 TORCH_VERSION_RAW = torch.__version__
@@ -32,10 +32,11 @@ if IS_ROCM:
 else:
     torch_cuda_version = torch.version.cuda  # type: ignore[attr-defined]
     cuda_major = torch_cuda_version.split(".")[0] if torch_cuda_version else None
-    if cuda_major != "12":
-        print("Only CUDA 12 wheels are hosted for flash-attn.")
+    if cuda_major not in ("12", "13"):
+        print(f"Only CUDA 12/13 wheels are hosted for flash-attn. Got CUDA {cuda_major}.")
         sys.exit(1)
-    cuda_version = "12"
+    # CUDA 13 wheels use "cu13" tag; CUDA 12 uses "cu12"
+    cuda_version = cuda_major
     wheel_filename = (
         f"flash_attn-{FLASH_VERSION}%2Bcu{cuda_version}torch{torch_version}"
         f"cxx11abi{cxx11_abi}-{python_version}-{python_version}-{platform_name}.whl"
@@ -44,10 +45,18 @@ else:
         f"flash_attn-{FLASH_VERSION}-{python_version}-{python_version}-{platform_name}.whl"
     )
 
-wheel_url = (
-    "https://dail-wlcb.oss-cn-wulanchabu.aliyuncs.com"
-    f"/AgentScope/download/flash-attn/{FLASH_VERSION}/{wheel_filename}"
-)
+if cuda_major == "13":
+    # CUDA 13 community wheels hosted on GitHub
+    wheel_url = (
+        "https://github.com/adithyaxx/flash-attention/releases/download"
+        f"/v{FLASH_VERSION}/flash_attn-{FLASH_VERSION}%2Bcu{cuda_version}torch{torch_version}"
+        f"cxx11abi{cxx11_abi}-{python_version}-{python_version}-{platform_name}.whl"
+    )
+else:
+    wheel_url = (
+        "https://dail-wlcb.oss-cn-wulanchabu.aliyuncs.com"
+        f"/AgentScope/download/flash-attn/{FLASH_VERSION}/{wheel_filename}"
+    )
 
 print(f"wheel_url: {wheel_url}")
 print(f"target_local_file: {local_filename}")

--- a/scripts/verl-git-override.txt
+++ b/scripts/verl-git-override.txt
@@ -1,10 +1,21 @@
-# uv override file: force verl to the #6551 merge commit (numpy>=2 plus the
-# vLLM/nccl/numpy-2 runtime fixes). Passed via `uv pip install --override ...`
-# on the registry/git install paths (scripts/install.sh, docker/Dockerfile),
-# because a normal direct requirement cannot satisfy verl>=0.8,<0.9 (the pinned
-# commit reports 0.9.0.dev0) and registry/pip-mode installs ignore pyproject
-# [tool.uv]. Keep in sync with the [tool.uv] override-dependencies in
-# pyproject.toml. Once verl publishes a release containing #6551, remove the
-# project override but keep this file at the same path with comments only, so
-# installed wrappers refresh away the temporary pin.
+# Temporary Verl override -- dependency decision record
+#
+# Decision: keep TuFT's published metadata as the normal, release-based
+# `verl>=0.8,<0.9` requirement, but have supported uv install paths replace it
+# with the pinned commit below via `--override`. The equivalent project-mode
+# override lives in pyproject.toml `[tool.uv].override-dependencies`.
+#
+# Rationale:
+# - Verl 0.8.0 pins NumPy <2, conflicting with TuFT's vLLM/OpenCV stack.
+# - verl-project/verl#6551 fixes the NumPy 2, vLLM, and NCCL runtime paths, but
+#   has not been released; its merge commit reports version 0.9.0.dev0.
+# - Adding that commit as a normal dependency would contradict TuFT's `<0.9`
+#   API cap and make the wheel metadata unsuitable for PyPI. A uv override
+#   substitutes the dependency only in the controlled installer/source/Docker
+#   flows while leaving the public compatibility contract explicit.
+#
+# Removal: after Verl publishes a compatible release, update the normal Verl
+# requirement and remove the pyproject override. Keep this file at this stable
+# path with comments only: previously installed `tuft upgrade` wrappers refresh
+# it before resolving, which removes the temporary pin for existing installs.
 verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0

--- a/scripts/verl-git-override.txt
+++ b/scripts/verl-git-override.txt
@@ -4,5 +4,7 @@
 # because a normal direct requirement cannot satisfy verl>=0.8,<0.9 (the pinned
 # commit reports 0.9.0.dev0) and registry/pip-mode installs ignore pyproject
 # [tool.uv]. Keep in sync with the [tool.uv] override-dependencies in
-# pyproject.toml; remove both once verl publishes a release containing #6551.
+# pyproject.toml. Once verl publishes a release containing #6551, remove the
+# project override but keep this file at the same path with comments only, so
+# installed wrappers refresh away the temporary pin.
 verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0

--- a/scripts/verl-git-override.txt
+++ b/scripts/verl-git-override.txt
@@ -1,0 +1,8 @@
+# uv override file: force verl to the #6551 merge commit (numpy>=2 plus the
+# vLLM/nccl/numpy-2 runtime fixes). Passed via `uv pip install --override ...`
+# on the registry/git install paths (scripts/install.sh, docker/Dockerfile),
+# because a normal direct requirement cannot satisfy verl>=0.8,<0.9 (the pinned
+# commit reports 0.9.0.dev0) and registry/pip-mode installs ignore pyproject
+# [tool.uv]. Keep in sync with the [tool.uv] override-dependencies in
+# pyproject.toml; remove both once verl publishes a release containing #6551.
+verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0

--- a/src/tuft/backends/fsdp_training_backend.py
+++ b/src/tuft/backends/fsdp_training_backend.py
@@ -218,12 +218,9 @@ def _datum_list_to_tensordict(
         "target_tokens": target_tokens.to(device),
         "weights": weights_device,
         "loss_mask": weights_device,
-        # Temperature shape (B, 1, 1): TensorDict requires all leaf tensors to
-        # have batch_size as a prefix dimension. A 0-dim scalar is rejected by
-        # td batch_size validation, and verl's use_remove_padding=True path does
-        # `logits.div_(temperature)` which broadcasts (B,1,1) -> (B, seq, V).
-        # Keep (B,1,1) — it is correct for both padded and rmpad paths.
-        "temperature": torch.full((batch_size, 1, 1), 1.0, device=device, dtype=torch.float32),
+        # Temperature: verl 0.8.0 expects (bsz,) and does unsqueeze internally.
+        # (verl 0.7.x expected (B,1,1) for direct broadcast, but 0.8.0 changed.)
+        "temperature": torch.ones(batch_size, device=device, dtype=torch.float32),
         "adapter_id": adapter_id,
     }
 
@@ -908,6 +905,11 @@ class VerlWorkerActor:
 
         os.environ["MASTER_ADDR"] = master_addr
         os.environ["MASTER_PORT"] = str(master_port)
+        # Must set CUDA device before init_process_group to avoid DeviceMesh
+        # picking wrong GPU (PyTorch 2.6+ creates DeviceMesh internally).
+        if torch.cuda.is_available():
+            local_rank = int(os.environ.get("LOCAL_RANK", self.rank))
+            torch.cuda.set_device(local_rank)
         dist.init_process_group(
             backend="nccl" if torch.cuda.is_available() else "gloo",
             rank=self.rank,
@@ -1160,19 +1162,37 @@ class FSDPTrainingBackend(BaseTrainingBackend):
             actors.append(actor)
         # Set _world_size / _actors only after all succeed; else next create_adapter retries init
         # get_node_ip should return quickly; timeout avoids hang when actor not scheduled (e.g. GPU)
-        _GET_NODE_IP_TIMEOUT = 30
-        master_addr = await asyncio.to_thread(
-            ray.get, actors[0].get_node_ip.remote(), timeout=_GET_NODE_IP_TIMEOUT
-        )
+        _GET_NODE_IP_TIMEOUT = 120
+        self.logger.info("[FSDP] async_init: created %d actors, calling get_node_ip...", n_gpus)
+        try:
+            master_addr = await asyncio.to_thread(
+                ray.get, actors[0].get_node_ip.remote(), timeout=_GET_NODE_IP_TIMEOUT
+            )
+        except Exception as e:
+            self.logger.error("[FSDP] get_node_ip FAILED: %s", e)
+            raise
+        self.logger.info("[FSDP] get_node_ip OK: %s, calling init_dist...", master_addr)
         base_port = getattr(self.config, "fsdp_master_port", DEFAULT_MASTER_PORT)
         master_port = base_port + self._fsdp_index if self._fsdp_index is not None else base_port
-        await asyncio.gather(
-            *[
-                asyncio.to_thread(ray.get, a.init_dist.remote(master_addr, master_port))
-                for a in actors
-            ]
-        )
-        await asyncio.gather(*[asyncio.to_thread(ray.get, a.build_worker.remote()) for a in actors])
+        try:
+            await asyncio.gather(
+                *[
+                    asyncio.to_thread(ray.get, a.init_dist.remote(master_addr, master_port))
+                    for a in actors
+                ]
+            )
+        except Exception as e:
+            self.logger.error("[FSDP] init_dist FAILED: %s", e)
+            raise
+        self.logger.info("[FSDP] init_dist OK, calling build_worker...")
+        try:
+            await asyncio.gather(
+                *[asyncio.to_thread(ray.get, a.build_worker.remote()) for a in actors]
+            )
+        except Exception as e:
+            self.logger.error("[FSDP] build_worker FAILED: %s", e)
+            raise
+        self.logger.info("[FSDP] build_worker OK, FSDP backend ready")
         self._actors = actors
         self._world_size = n_gpus
 

--- a/src/tuft/backends/fsdp_training_backend.py
+++ b/src/tuft/backends/fsdp_training_backend.py
@@ -214,13 +214,26 @@ def _datum_list_to_tensordict(
     batch_size = len(input_ids_list)
     weights_device = weights.to(device)
 
+    # Temperature: verl 0.8.0 expects a 1-D (B,) tensor and unsqueezes it
+    # internally before `logits.div_(temperature)`. (verl 0.7.x expected
+    # (B,1,1) for direct broadcast, but 0.8.0 changed.) It is all-ones here, so
+    # the scaling is a no-op — the field exists only to satisfy verl's engine
+    # contract. Pin the rank/shape explicitly: the TensorDict below already
+    # checks the leading dim == batch_size, but NOT that it is 1-D, so this
+    # guards against silently regressing to the 0.7.x (B,1,1) shape (or any
+    # other rank) that a verl bump might mis-broadcast across the vocab dim.
+    temperature = torch.ones(batch_size, device=device, dtype=torch.float32)
+    assert temperature.shape == (batch_size,), (
+        f"temperature must be 1-D (B,)=({batch_size},) for verl 0.8.0's internal "
+        f"unsqueeze before logits.div_(temperature); got {tuple(temperature.shape)}. "
+        "If this fires after a verl upgrade, re-check verl's temperature handling "
+        "(see the use_remove_padding note below) before changing the shape."
+    )
     td_dict = {
         "target_tokens": target_tokens.to(device),
         "weights": weights_device,
         "loss_mask": weights_device,
-        # Temperature: verl 0.8.0 expects (bsz,) and does unsqueeze internally.
-        # (verl 0.7.x expected (B,1,1) for direct broadcast, but 0.8.0 changed.)
-        "temperature": torch.ones(batch_size, device=device, dtype=torch.float32),
+        "temperature": temperature,
         "adapter_id": adapter_id,
     }
 
@@ -257,10 +270,12 @@ def _datum_list_to_tensordict(
         micro_batch_size_per_gpu=mb,
         # use_remove_padding=False: we use NO_PADDING pad_mode (jagged tensors)
         # but NOT verl's rmpad path because rmpad does
-        #   `logits_rmpad.div_(temperature)` with a scalar temperature
-        # while our TensorDict-resident temperature must be (B,1,1) to pass
-        # TensorDict batch_size validation. These two constraints conflict;
-        # fixing requires monkey-patching verl's prepare_model_outputs (TODO).
+        #   `logits_rmpad.div_(temperature)` expecting a scalar temperature,
+        # while our TensorDict-resident temperature is (B,) (see the temperature
+        # note above): it must carry a leading batch dim to pass TensorDict
+        # batch_size validation, so it can't be a bare scalar. These two
+        # constraints conflict; fixing requires monkey-patching verl's
+        # prepare_model_outputs (TODO).
         # With False + jagged nested tensors + NO_PADDING, verl pads to
         # max_seq_len internally, forwards, then narrows logits back per
         # sample, so per-sample logprob lengths still equal their real
@@ -293,6 +308,19 @@ def _make_verl_loss_fn(
         log_probs_nt = model_output["log_probs"]
         weights = data["weights"]
         batch_size, max_len = weights.shape
+        # Guard (verl 0.8.0 contract): with use_remove_padding=False + NO_PADDING,
+        # verl narrows logits back per sample, so log_probs is a nested
+        # (B, per_sample_len) tensor whose batch dim must equal B (the padded
+        # (B, max_len) view below then aligns per sample). This is the same
+        # forward/narrow path that applies `logits.div_(temperature)`, so a verl
+        # upgrade that changes it trips here loudly instead of silently
+        # misaligning logprobs. (Over-length samples are already caught by
+        # to_padded_tensor's output_size.)
+        assert log_probs_nt.size(0) == batch_size, (
+            f"verl returned log_probs with batch dim {log_probs_nt.size(0)} != "
+            f"expected {batch_size}; verl's forward/temperature path may have changed — "
+            "re-verify before bumping verl past 0.8.x."
+        )
         target_logprobs = torch.nested.to_padded_tensor(
             log_probs_nt, padding=0.0, output_size=(batch_size, max_len)
         )
@@ -906,10 +934,14 @@ class VerlWorkerActor:
         os.environ["MASTER_ADDR"] = master_addr
         os.environ["MASTER_PORT"] = str(master_port)
         # Must set CUDA device before init_process_group to avoid DeviceMesh
-        # picking wrong GPU (PyTorch 2.6+ creates DeviceMesh internally).
+        # picking the wrong GPU (PyTorch 2.6+ creates DeviceMesh internally).
+        # Each actor is a Ray num_gpus=1 process: Ray sets CUDA_VISIBLE_DEVICES
+        # to a single physical GPU that torch sees as cuda:0. Do NOT use the
+        # global rank (self.rank) here — rank>=1 would select a nonexistent
+        # local device and fail before NCCL init. Exactly one device is visible,
+        # so always pin index 0.
         if torch.cuda.is_available():
-            local_rank = int(os.environ.get("LOCAL_RANK", self.rank))
-            torch.cuda.set_device(local_rank)
+            torch.cuda.set_device(0)
         dist.init_process_group(
             backend="nccl" if torch.cuda.is_available() else "gloo",
             rank=self.rank,

--- a/src/tuft/backends/sampling_backend.py
+++ b/src/tuft/backends/sampling_backend.py
@@ -290,6 +290,11 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                 "env_vars": {
                     "VIRTUAL_ENV": self._worker_venv_path,
                     "PATH": f"{self._worker_venv_path}/bin:{_path}",
+                    # vLLM v1 EngineCore worker requests VLLM_RAY_PER_WORKER_GPUS
+                    # from Ray by default. In standalone DP mode the parent actor
+                    # already holds the GPU; set to 0 so the child worker doesn't
+                    # double-count and exhaust the cluster GPU quota.
+                    "VLLM_RAY_PER_WORKER_GPUS": "0",
                 },
             }
 

--- a/src/tuft/backends/sampling_backend.py
+++ b/src/tuft/backends/sampling_backend.py
@@ -290,11 +290,6 @@ class VLLMSamplingBackend(BaseSamplingBackend):
                 "env_vars": {
                     "VIRTUAL_ENV": self._worker_venv_path,
                     "PATH": f"{self._worker_venv_path}/bin:{_path}",
-                    # vLLM v1 EngineCore worker requests VLLM_RAY_PER_WORKER_GPUS
-                    # from Ray by default. In standalone DP mode the parent actor
-                    # already holds the GPU; set to 0 so the child worker doesn't
-                    # double-count and exhaust the cluster GPU quota.
-                    "VLLM_RAY_PER_WORKER_GPUS": "0",
                 },
             }
 


### PR DESCRIPTION
## Summary

Adds end-to-end support for Qwen3.5-4B training by upgrading to the latest trinity-rft, verl, transformers, and flash-attn stack.

## Changes

### Dependency upgrades (`pyproject.toml`)
- `trinity-rft[vllm]>=0.5.2`
- `verl>=0.8.0`
- `transformers>=5.2,<6`
- `huggingface-hub>=1.3`
- Added `numpy` to dependencies
- Added `[tool.uv]` override-dependencies for verl to resolve transitive pin conflicts

### FSDP training backend (`fsdp_training_backend.py`)
- Fix temperature tensor shape: `torch.full((B,1,1), 1.0)` → `torch.ones(B)` for verl 0.8.0 compatibility
- Call `torch.cuda.set_device()` before `dist.init_process_group` to avoid multi-GPU NCCL issues
- Add `async_init` logging for better observability during FSDP cold start

### Sampling backend (`sampling_backend.py`)
- Set `VLLM_RAY_PER_WORKER_GPUS=0` in Ray runtime env to prevent vLLM v1 engine from over-allocating GPUs

### flash-attn installer (`scripts/install_flash_attn.py`)
- Update to flash-attn 2.8.3
- Add CUDA 13 wheel detection and installation support

## Files Changed
- `pyproject.toml` (+16/-6)
- `scripts/install_flash_attn.py` (+15/-10)
- `src/tuft/backends/fsdp_training_backend.py` (+35/-19)
- `src/tuft/backends/sampling_backend.py` (+4/-1)

## Test Plan

- [x] Qwen3.5-4B 32k SFT training on single A100-80GB (6/6 runs passed)
- [x] Pre-commit checks pass (ruff, pyright, detect-secrets, pytest)
- [x] flash-attn installs correctly on CUDA 13 environment