### PR TITLE
ci(install-script): stop `tuft launch` test from hanging CI

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -25,6 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
+    # Backstop so a blocking step (e.g. `tuft launch`) can't hang for the
+    # default 6h job timeout. Normal runs finish in ~3-4 min.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -97,9 +100,31 @@ jobs:
           authorized_users:
             test-key: test-user
           EOF
-          # Launch should fail due to missing model, but get past config validation
-          # We just verify it doesn't fail on config parsing
-          tuft launch 2>&1 | grep -v "Configuration file must be provided" || true
+          # `tuft launch` is a blocking uvicorn server: with a valid config it
+          # passes validation and serves (models load lazily, so a bad
+          # model_path does NOT make it exit). Run it in the background and stop
+          # it after it has had time to start, so CI can't hang on the server.
+          # Portable (no `timeout`, which isn't on macOS): we just smoke-test
+          # that launch accepts the config and starts up.
+          tuft launch > launch.log 2>&1 &
+          launch_pid=$!
+          sleep 60
+          if kill -0 "$launch_pid" 2>/dev/null; then
+            echo "OK: tuft launch is still serving after startup (config validation passed)"
+          else
+            echo "tuft launch exited on its own within 60s; output:"
+            cat launch.log
+          fi
+          # Stop the server and its children. SIGKILL is uncatchable, and we
+          # deliberately do NOT `wait` (the server ignores SIGTERM), so this
+          # never blocks the job.
+          pkill -KILL -P "$launch_pid" 2>/dev/null || true
+          kill -KILL "$launch_pid" 2>/dev/null || true
+          # Fail only if launch never accepted the provided config file.
+          if grep -q "Configuration file must be provided" launch.log; then
+            echo "FAIL: tuft launch did not pick up the provided config"
+            exit 1
+          fi
         env:
           TUFT_HOME: ${{ runner.temp }}/tuft
 


### PR DESCRIPTION
## Problem

The `test-install-script` job hangs on the **"Test tuft launch with config file"** step and runs until the default **6-hour** job timeout. It already cancelled a run on `main` at 6h0m (modify version number to 0.1.6, #115), and most recently hung PR #124's CI.

### Root cause
`tuft launch` ([src/tuft/cli.py](src/tuft/cli.py)) is a **blocking uvicorn server**:
1. `_build_config()` validates the YAML — the test's dummy config is valid, so this passes. (The "Configuration file must be provided" error only fires when *no* config resolves.)
2. Falls through to `uvicorn.run()`, which serves forever.

Models load lazily, so `model_path: /nonexistent/path` never triggers an early exit. The step's premise ("Launch should fail due to missing model") is wrong — the server just starts and stays up, and the piped `... | grep ... || true` never returns because `tuft launch` never exits. There's no per-step/job timeout, so it inherits the 6h default.

(On macOS the server exits on its own after ~70s, which is why that matrix leg passed under the old `|| true`.)

## Fix

- **Run `tuft launch` in the background**, give it time to start, then **stop it** instead of waiting for an exit that never comes. This smoke-tests that launch accepts the config and starts up, without blocking.
- **Use SIGKILL and do not `wait`.** The server ignores SIGTERM, so a SIGTERM-then-`wait` would itself hang (the failure mode of an earlier revision of this PR). SIGKILL is uncatchable and skipping `wait` guarantees the step returns immediately.
- **Portable** across Linux/macOS — deliberately avoids `timeout` (not present on macOS runners) and preserves the macOS leg's behavior.
- Still **fails** if launch never accepts the provided config (`Configuration file must be provided`).
- Adds **`timeout-minutes: 15`** on the job as a backstop so any future blocking step can't eat the full 6h.

```bash
tuft launch > launch.log 2>&1 &
launch_pid=$!
sleep 60
if kill -0 "$launch_pid" 2>/dev/null; then
  echo "OK: tuft launch is still serving after startup (config validation passed)"
else
  echo "tuft launch exited on its own within 60s; output:"
  cat launch.log
fi
# Stop the server and its children. SIGKILL is uncatchable, and we
# deliberately do NOT `wait` (the server ignores SIGTERM), so this
# never blocks the job.
pkill -KILL -P "$launch_pid" 2>/dev/null || true
kill  -KILL "$launch_pid"    2>/dev/null || true
if grep -q "Configuration file must be provided" launch.log; then
  echo "FAIL: tuft launch did not pick up the provided config"
  exit 1
fi
```

## Verified

Full run on this branch is green — the previously-hanging leg now finishes in minutes:

| Job | Before | After |
|---|---|---|
| `test-install-script (ubuntu-latest)` | hung → 6h timeout | ✅ **2m50s** |
| `test-install-script (macos-latest)` | ✅ | ✅ 1m51s |
| other jobs | ✅ | ✅ ~1m20–1m35s |

## Notes
- **Scope:** only `.github/workflows/install-script.yml`. Separate from the workflow-hardening in #124 (this is a pre-existing `main` bug).
- This is a **smoke test**: it confirms `tuft launch` accepts the config and starts serving, and fails if the config is rejected. Because models load lazily, it does not exercise actual model loading — matching the original test's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)