### PR TITLE
docs(deployment): add Deployment section with Modal + Lambda guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ TuFT (**T**enant-**u**nified **F**ine**T**uning) is a multi-tenant platform that
   <img src="https://img.alicdn.com/imgextra/i3/O1CN01M7FlDa1LkOf90UsHk_!!6000000001337-2-tps-4000-2250.png" alt="TuFT Overview" width="800"/>
 </div>
 
+> [!TIP]
+> **🚀 No GPU? No problem!** You can deploy TuFT to a pay-as-you-go cloud provider — **Modal** (serverless, scale-to-zero) or **Lambda Cloud** — and fine-tune from your laptop with no local GPU. See [Deployment](#deployment).
+
 Check out our [roadmap](#roadmap) to see what we're building next.
 
 We're open source and welcome contributions! Join the community:
@@ -32,6 +35,7 @@ We're open source and welcome contributions! Join the community:
 - [Quick Start Example](#quick-start-example)
 - [Installation](#installation)
 - [Use the Pre-built Docker Image](#use-the-pre-built-docker-image)
+- [Deployment](#deployment)
 - [User Guide](#user-guide)
 - [Architecture](#architecture)
 - [Roadmap](#roadmap)
@@ -328,6 +332,17 @@ you can use the pre-built Docker image.
         max_model_len: 32768
         tensor_parallel_size: 1
     ```
+
+## Deployment
+
+Don't have a GPU? Run TuFT on **pay-as-you-go cloud compute** — rent a GPU on demand and fine-tune from your laptop (no local GPU). The [`deploy/`](deploy/) helpers wrap the standard `tuft launch` server for popular cloud backends and walk you through configuring the deployment, running an end-to-end "talk like Yoda" training example on `Qwen/Qwen3-0.6B`, and downloading the trained adapter.
+
+| Backend | Description |
+|---|---|
+| [Modal](https://agentscope-ai.github.io/TuFT/en/latest/deployment/modal.html) | Serverless GPUs with **scale-to-zero** and per-second billing. |
+| [Lambda Cloud](https://agentscope-ai.github.io/TuFT/en/latest/deployment/lambda.html) | A plain on-demand GPU VM, billed per minute until you terminate. |
+
+See the full [Deployment guides](https://agentscope-ai.github.io/TuFT/en/latest/deployment/index.html) in the documentation.
 
 ## User Guide
 

--- a/docs/sphinx_doc/source/deployment/index.md
+++ b/docs/sphinx_doc/source/deployment/index.md
@@ -1,0 +1,68 @@
+# Deployment
+
+```{admonition} 🚀 No GPU? No problem!
+:class: tip
+
+You don't need to own a GPU to run TuFT. These guides show how to stand up a TuFT
+server on **pay-as-you-go cloud providers** — rent a GPU on demand and release it when
+you're done. Train from your laptop (no local GPU) by pointing the
+[Tinker](https://github.com/thinking-machines-lab/tinker) SDK at the cloud server.
+```
+
+TuFT is a single, standard server (`tuft launch`). The deploy helpers in the
+[`deploy/`](https://github.com/agentscope-ai/TuFT/tree/main/deploy) directory just run
+that exact server on rented compute and wire up storage, ports, and secrets for you —
+they don't change anything about the product. Pick the backend that fits your workflow:
+
+```{grid} 1 2 2 2
+:gutter: 3
+
+:::{grid-item-card} Modal
+:link: modal
+:link-type: doc
+:shadow: none
+
+**Serverless, scale-to-zero.** Deploys a web endpoint that scales to zero when idle,
+billed per second. Suited to bursty or intermittent use.
+:::
+
+:::{grid-item-card} Lambda Cloud
+:link: lambda
+:link-type: doc
+:shadow: none
+
+**A plain on-demand GPU VM**, billed per minute until you terminate it. No orchestration
+layer; the instance runs until you stop it.
+:::
+```
+
+## Which one should I pick?
+
+| If you want… | Use | Description |
+|---|---|---|
+| To scale to zero when idle | **[Modal](modal.md)** | Serverless; scale-to-zero, per-second billing, managed proxy and volumes. |
+| A single dedicated GPU instance | **[Lambda Cloud](lambda.md)** | On-demand, billed per minute until you terminate; no orchestration layer, no preemption. |
+
+## Keeping the GPU busy
+
+A single laptop-driven training run leaves the rented GPU **under-utilized**: the client
+tokenizes data, builds batches, and waits on HTTP round-trips between GPU bursts, so the GPU
+sits idle for much of the run. Because TuFT is **multi-tenant**, one deployed server can host
+**several concurrent jobs or users** on the same GPU — give each their own key under
+`authorized_users`, and raise `max_loras` so multiple LoRA adapters can train at once. Sharing
+this way improves utilization and splits the cost. It matters most on **Lambda** (billed
+continuously whether or not the GPU is working) and during active **Modal** sessions (the
+container is warm but the GPU is bursty).
+
+Both guides walk through the **same end-to-end example**: configuring the server,
+deploying it, training a "talk like Yoda" LoRA on `Qwen/Qwen3-0.6B` from your laptop, and
+downloading the trained adapter — all reusing the runnable code in
+[`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft).
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+modal
+lambda
+```

--- a/docs/sphinx_doc/source/deployment/lambda.md
+++ b/docs/sphinx_doc/source/deployment/lambda.md
@@ -1,0 +1,285 @@
+# Deploy on Lambda Cloud
+
+[Lambda Cloud](https://lambda.ai) rents plain on-demand GPU VMs, billed per minute until you
+terminate them — no orchestration layer and no preemption. This guide
+takes you end to end — configure a TuFT server, launch it on a Lambda GPU, train a "talk
+like Yoda" LoRA on `Qwen/Qwen3-0.6B` from your laptop, and download the adapter — with **no
+local GPU required**.
+
+```{admonition} What you'll build
+:class: note
+
+A TuFT server running on a Lambda GPU VM (auto-provisioned and self-bootstrapped via Docker),
+which you reach over an SSH tunnel and fine-tune from your laptop using the runnable code in
+[`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft).
+```
+
+```{admonition} Lambda has no scale-to-zero
+:class: warning
+
+Unlike Modal, a Lambda VM **bills continuously until you terminate it** — there is no
+idle/auto-stop. Always tear the instance down when you're done (see [Step 5](#step-5-tear-down)).
+```
+
+## Prerequisites
+
+1. **A Lambda Cloud account, API key, and SSH key.** In the
+   [Lambda Cloud dashboard](https://cloud.lambda.ai), generate an API key
+   ([API keys](https://cloud.lambda.ai/api-keys)) and register an SSH public key
+   ([SSH keys](https://cloud.lambda.ai/ssh-keys)) — you'll use the matching private key to
+   reach the server. See Lambda's [docs](https://docs.lambda.ai) for details. Export the API
+   key so the launcher can find it:
+
+   ```bash
+   export LAMBDA_API_KEY=secret_...
+   ```
+
+2. **The TuFT repo.** The deploy helper talks to Lambda's HTTP API; it only needs `pyyaml`
+   locally (all GPU dependencies run inside the container on the VM):
+
+   ```bash
+   git clone https://github.com/agentscope-ai/TuFT
+   cd TuFT
+   pip install pyyaml
+   ```
+
+## Step 1 — Configure the server
+
+The deploy helper [`deploy/lambda/launch.py`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/lambda/launch.py)
+is **config-file driven** and mirrors the Modal launcher: you edit a standard
+`tuft_config.yaml` and run the script. Lambda infra goes in an optional `lambda:` section
+that is stripped before the server sees it.
+
+Save this as `yoda_lambda.yaml`:
+
+```yaml
+checkpoint_dir: ~/.cache/tuft/checkpoints   # mapped to the VM's /data; see Step 4 about durability
+model_owner: cloud-user
+
+supported_models:
+  - model_name: Qwen/Qwen3-0.6B
+    model_path: Qwen/Qwen3-0.6B            # HF id (downloaded on first launch) or a local path
+    max_model_len: 4096
+    tensor_parallel_size: 1
+    colocate: true                         # single GPU: training + vLLM sampling share it
+    sampling_memory_fraction: 0.4
+    max_lora_rank: 16
+    max_loras: 2
+
+authorized_users:
+  tml-REPLACE_WITH_A_STRONG_KEY: cloud-user  # clients send this as the X-API-Key header
+
+persistence:
+  mode: DISABLE
+
+telemetry:
+  enabled: false
+
+# Lambda Cloud infra for deploy/lambda/launch.py (TuFT ignores this; it's stripped before the server sees it):
+lambda:
+  gpu: a100              # family hint; auto-pick prefers a100
+  name: tuft-yoda
+  # ssh_key: my-key      # default: your account's sole registered key
+  # filesystem: tuft     # Lambda persistent filesystem for durable checkpoints (else ephemeral root disk)
+```
+
+Generate a real API key for `authorized_users` (it **must** start with `tml-`):
+
+```bash
+python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+```
+
+```{admonition} Pick a100, not a10, for training
+:class: warning
+
+The cheapest Lambda GPU (`gpu_1x_a10`, sm_86) has a known issue in the current TuFT image:
+**serving works, but training returns null logprobs**. Auto-select therefore **prefers
+a100** and uses a10 only as a last resort. For this training example, stay on a100.
+```
+
+## Step 2 — Launch the GPU server
+
+Run the launcher. With no instance pinned, it auto-selects the cheapest available GPU that
+matches your `gpu:` hint, provisions it, and self-bootstraps TuFT in Docker via cloud-init
+(no manual SSH needed):
+
+```bash
+python deploy/lambda/launch.py --config yoda_lambda.yaml
+```
+
+It prints the chosen instance and, once the VM is up, a connect banner with an SSH-tunnel
+command and the instance id:
+
+```text
+[launch] gpu_1x_a100_sxm4 in us-east-1 (~$1.99/hr), ssh_key=my-key, name=tuft-yoda
+[launch] provisioning instance abcd...  (this takes a minute)
+[launch] instance abcd1234... is active at 203.0.113.45
+
+Connect securely over an SSH tunnel (recommended; keeps :10610 off the public net):
+    ssh -N -L 10610:localhost:10610 ubuntu@203.0.113.45
+```
+
+```{tip}
+Check or list instances any time with `python deploy/lambda/launch.py --status`. To reuse an
+existing instance instead of launching a new one, pass `--instance-id <id>`.
+```
+
+## Step 3 — Train the Yoda LoRA from your laptop
+
+Open the SSH tunnel printed above in one terminal (the first boot pulls the image and loads
+vLLM, which can take a few minutes):
+
+```bash
+ssh -N -L 10610:localhost:10610 ubuntu@203.0.113.45
+```
+
+```{note}
+The training still runs **on your laptop** — `train.py` is a CPU-only client that drives the
+loop over HTTP. The `-L 10610:localhost:10610` flag forwards your laptop's port `10610` to the
+server's port `10610` on the VM, so `http://localhost:10610` (used below) is only the *local
+end* of the tunnel: every request is carried over SSH to the **remote GPU**, where the training
+and sampling actually run. Keep this SSH terminal open for the whole run. (Prefer not to tunnel?
+You can point `--base-url` at `http://<vm-ip>:10610` directly instead, but that exposes the API
+on the public internet.)
+```
+
+In a second terminal, confirm the server is healthy through the tunnel:
+
+```bash
+curl http://localhost:10610/api/v1/healthz
+# {"status":"ok"}
+```
+
+The training script [`examples/personality_sft/train.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/train.py)
+is a **client** that drives the loop over HTTP via the Tinker SDK — it needs only CPU-side
+dependencies:
+
+```bash
+pip install tinker transformers
+```
+
+The dataset is ~50 hand-authored `(user, assistant-in-Yoda-voice)` pairs in
+[`dataset.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/dataset.py).
+Only the **assistant** tokens get loss weight (the prompt is masked), so the model learns
+the *voice*, not the questions. A couple of example pairs:
+
+```python
+YODA_PAIRS = [
+    (
+        "How do I stay motivated?",
+        "Motivated, you wish to stay? Hmm. Small steps each day, take you must. "
+        "Begin, and momentum follows. Do or do not — there is no try.",
+    ),
+    (
+        "What's the best way to learn programming?",
+        "Patient you must be, young one. Write code daily, you should. "
+        "Fail often, learn faster you will. Much to learn, you still have.",
+    ),
+    # ... ~50 pairs total
+]
+```
+
+Point the script at the tunnel (`http://localhost:10610`), pass the `tml-` key, and select
+the model (it must match the `supported_models` entry on the server):
+
+```bash
+python examples/personality_sft/train.py \
+    --base-url http://localhost:10610 \
+    --api-key tml-REPLACE_WITH_A_STRONG_KEY \
+    --model Qwen/Qwen3-0.6B
+```
+
+The script samples the base model **before** training, runs 60 LoRA steps, then samples the
+trained adapter **after** so you can see the personality emerge:
+
+```text
+[before] sampling base model on held-out prompts
+   [base] Give me advice on becoming a better person.
+      -> Focus on small consistent habits: be honest, listen to others, and learn from your mistakes.
+   [base] What's the key to writing good software?
+      -> Keep it readable and well-tested, prefer small functions, and document your intent.
+
+[train] 60 steps, batch 8, lr 0.0001, rank 16
+   step   0  loss=2.3987
+   step  10  loss=1.7765
+   step  50  loss=1.2410
+   step  59  loss=1.1702
+
+[save] sampler=tinker://abcd1234.../yoda-sampler
+[save] run_id=abcd1234-...
+
+[after] sampling the trained adapter
+   [yoda] Give me advice on becoming a better person.
+      -> Small steps each day, take you must. Honest, be. Listen more than speak, you should. Grow, you will, hmm.
+   [yoda] What's the key to writing good software?
+      -> Simple, keep it, you must. Read aloud your code, you should. Fail often, learn faster you will, young one.
+```
+
+```{tip}
+Tunables: `--lora-rank`, `--num-steps`, `--batch-size`, `--learning-rate`, `--max-length`.
+Pass `--no-before` to skip the base-model sampling. Edit `dataset.py` to swap in a different
+character.
+```
+
+## Step 4 — Download the adapter
+
+Training writes a standard [PEFT](https://huggingface.co/docs/peft) LoRA adapter to the
+server's `checkpoint_dir`, which on the VM lives under `/home/ubuntu/tuft-data/checkpoints`.
+The script prints a `run_id` — copy the adapter off the instance with `scp`:
+
+```bash
+scp -r ubuntu@203.0.113.45:/home/ubuntu/tuft-data/checkpoints/<run_id> ./weights/
+# -> ./weights/<run_id>/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
+```
+
+```{admonition} Download before you terminate
+:class: warning
+
+By default checkpoints live on the instance's **ephemeral root disk** — terminating the VM
+(Step 5) destroys them. **Download first**, or launch with a persistent `filesystem:` (a
+[Lambda filesystem](https://docs.lambda.ai)) so checkpoints survive termination.
+```
+
+Optionally merge the adapter into full model weights (needs `torch`, `peft`, `transformers`):
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, "./weights/<run_id>/yoda-final/adapter").merge_and_unload()
+merged.save_pretrained("./yoda-merged")   # standard HF model dir, servable by vLLM
+```
+
+(step-5-tear-down)=
+## Step 5 — Tear down
+
+Lambda bills until you terminate, so always shut the instance down when finished:
+
+```bash
+python deploy/lambda/launch.py --down --instance-id abcd1234...
+# or by name:
+python deploy/lambda/launch.py --down --name tuft-yoda
+```
+
+Verify nothing is left running:
+
+```bash
+python deploy/lambda/launch.py --status
+```
+
+```{tip}
+Lambda bills the GPU continuously, so a single laptop-driven run **pays for a lot of idle
+time**. Because TuFT is multi-tenant, you can point **several concurrent jobs or users** at the
+same instance (each with a key under `authorized_users`; raise `max_loras` for more adapters at
+once) to keep the GPU busy and split the cost. See
+[Keeping the GPU busy](index.md#keeping-the-gpu-busy).
+```
+
+## Next steps
+
+- Try a bigger model (e.g. `Qwen/Qwen3-4B`) by changing both names in the config; the
+  auto-picked a100 (80 GB) has ample room.
+- Prefer a scale-to-zero option? See the [Modal guide](modal.md).
+- Browse [Lambda's docs](https://docs.lambda.ai) for instance types, regions, and filesystems.

--- a/docs/sphinx_doc/source/deployment/modal.md
+++ b/docs/sphinx_doc/source/deployment/modal.md
@@ -1,0 +1,254 @@
+# Deploy on Modal
+
+[Modal](https://modal.com) is a serverless GPU platform: you deploy a container and it
+runs on a GPU only while requests are in flight, scaling to zero when idle. This guide
+takes you end to end — configure a TuFT server, deploy it to Modal, train a "talk like
+Yoda" LoRA on `Qwen/Qwen3-0.6B` from your laptop, and download the adapter — with **no
+local GPU required**.
+
+```{admonition} What you'll build
+:class: note
+
+A TuFT server running on a Modal L4 GPU, reachable at a public `…modal.run` URL, that you
+fine-tune from your laptop using the runnable code in
+[`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft).
+```
+
+## Prerequisites
+
+1. **A Modal account + CLI.** Install the client and authenticate (this opens a browser to
+   create an API token — see Modal's [Getting started](https://modal.com/docs/guide) and
+   [`modal token`](https://modal.com/docs/reference/cli/token) docs):
+
+   ```bash
+   pip install modal
+   modal token new
+   ```
+
+2. **The TuFT repo.** The deploy helper and the training example live in the repo; the
+   launcher itself only needs `modal` + `pyyaml` locally (the heavy GPU dependencies run
+   inside Modal's container, not on your machine):
+
+   ```bash
+   git clone https://github.com/agentscope-ai/TuFT
+   cd TuFT
+   pip install modal pyyaml
+   ```
+
+`Qwen/Qwen3-0.6B` is openly downloadable, so no Hugging Face token is needed. For **gated**
+models, create a [Modal Secret](https://modal.com/docs/guide/secrets) holding your
+`HF_TOKEN` and pass `--hf-secret <secret-name>` to the launcher.
+
+## Step 1 — Configure the server
+
+The deploy helper [`deploy/modal/launch.py`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/modal/launch.py)
+is **config-file driven**: you edit a standard `tuft_config.yaml` (the same file
+`tuft launch --config` uses) and run the script. Modal infra goes in an optional `modal:`
+section that is stripped before the server sees it.
+
+Save this as `yoda_modal.yaml`:
+
+```yaml
+checkpoint_dir: ~/.cache/tuft/checkpoints   # on Modal, launch.py pins this to a Volume automatically
+model_owner: cloud-user
+
+supported_models:
+  - model_name: Qwen/Qwen3-0.6B
+    model_path: Qwen/Qwen3-0.6B            # HF id (downloaded on first launch) or a local path
+    max_model_len: 4096
+    tensor_parallel_size: 1
+    colocate: true                         # single GPU: training + vLLM sampling share it
+    sampling_memory_fraction: 0.4
+    max_lora_rank: 16
+    max_loras: 2
+
+authorized_users:
+  tml-REPLACE_WITH_A_STRONG_KEY: cloud-user  # clients send this as the X-API-Key header
+
+persistence:
+  mode: DISABLE
+
+telemetry:
+  enabled: false
+
+# Modal infra for deploy/modal/launch.py (TuFT ignores this; it's stripped before the server sees it):
+modal:
+  gpu: L4
+  name: tuft-yoda
+  proxy_auth: false      # the tml- API key is the auth; the Tinker SDK can't send Modal gateway headers
+  min_containers: 0      # scale to zero when idle
+```
+
+Generate a real API key for `authorized_users` (it **must** start with `tml-`):
+
+```bash
+python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+```
+
+```{tip}
+A ready-made example with all available options is
+[`deploy/modal/tuft_config.example.yaml`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/modal/tuft_config.example.yaml),
+and the example used below ships its own
+[`config.yaml`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/config.yaml).
+```
+
+## Step 2 — Deploy to Modal
+
+Run the launcher in the **foreground** so the server is torn down automatically when you
+press `Ctrl-C`:
+
+```bash
+python deploy/modal/launch.py --config yoda_modal.yaml --foreground
+```
+
+The script renders a self-contained Modal app (a
+[`@modal.web_server`](https://modal.com/docs/guide/webhooks)) and serves it. It prints a
+public URL — copy it:
+
+```text
+✓ Created web endpoint => https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run
+```
+
+Confirm the server is up (the health route needs no auth; first call cold-starts the image
+and loads vLLM, which can take a few minutes):
+
+```bash
+curl https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run/api/v1/healthz
+# {"status":"ok"}
+```
+
+**Deploy modes.** `--foreground` (used here) wraps `modal serve` — convenient for an
+interactive run; `Ctrl-C` stops it. Omit it for a **detached** deploy (`modal deploy`) that
+keeps running until you `--down` it:
+
+```bash
+python deploy/modal/launch.py --config yoda_modal.yaml          # detached
+python deploy/modal/launch.py --down --name tuft-yoda           # stop it later
+```
+
+`checkpoint_dir` is automatically pinned to a [Modal Volume](https://modal.com/docs/guide/volumes)
+(`tuft-checkpoints`) so your adapters survive container shutdown.
+
+## Step 3 — Train the Yoda LoRA from your laptop
+
+The training script [`examples/personality_sft/train.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/train.py)
+is a **client** that connects to the running server over HTTP via the Tinker SDK — it needs
+only CPU-side dependencies:
+
+```bash
+pip install tinker transformers
+```
+
+The dataset is ~50 hand-authored `(user, assistant-in-Yoda-voice)` pairs in
+[`dataset.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/dataset.py).
+Only the **assistant** tokens get loss weight (the prompt is masked), so the model learns
+the *voice*, not the questions. A couple of example pairs:
+
+```python
+YODA_PAIRS = [
+    (
+        "How do I stay motivated?",
+        "Motivated, you wish to stay? Hmm. Small steps each day, take you must. "
+        "Begin, and momentum follows. Do or do not — there is no try.",
+    ),
+    (
+        "What's the best way to learn programming?",
+        "Patient you must be, young one. Write code daily, you should. "
+        "Fail often, learn faster you will. Much to learn, you still have.",
+    ),
+    # ... ~50 pairs total
+]
+```
+
+Point the script at your Modal URL, pass the `tml-` key, and select the model (it must
+match the `supported_models` entry on the server):
+
+```bash
+python examples/personality_sft/train.py \
+    --base-url https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run \
+    --api-key tml-REPLACE_WITH_A_STRONG_KEY \
+    --model Qwen/Qwen3-0.6B
+```
+
+The script samples the base model **before** training, runs 60 LoRA steps, then samples the
+trained adapter **after** so you can see the personality emerge:
+
+```text
+[before] sampling base model on held-out prompts
+   [base] How should I spend my weekend?
+      -> You could relax, catch up on friends, or work on a hobby. Try to balance rest with something fun.
+   [base] I'm nervous about starting a new job.
+      -> That's normal. Prepare a little, get good sleep, and remember they hired you for a reason.
+
+[train] 60 steps, batch 8, lr 0.0001, rank 16
+   step   0  loss=2.4131
+   step  10  loss=1.8027
+   step  50  loss=1.2563
+   step  59  loss=1.1894
+
+[save] sampler=tinker://abcd1234.../yoda-sampler
+[save] run_id=abcd1234-...
+
+[after] sampling the trained adapter
+   [yoda] How should I spend my weekend?
+      -> Rest and adventure, balance them you must, hmm. Outside, go — the Force in nature lives. Restored, you will be.
+   [yoda] I'm nervous about starting a new job.
+      -> Nervous, you are? Natural, this fear is. Breathe, you must. Chosen, you were — trust yourself, young one.
+```
+
+```{tip}
+Tunables: `--lora-rank`, `--num-steps`, `--batch-size`, `--learning-rate`, `--max-length`.
+Pass `--no-before` to skip the base-model sampling. Edit `dataset.py` to swap in a
+different character.
+```
+
+## Step 4 — Download the adapter
+
+Training writes a standard [PEFT](https://huggingface.co/docs/peft) LoRA adapter to the
+server's `checkpoint_dir`, which on Modal is the `tuft-checkpoints`
+[Volume](https://modal.com/docs/guide/volumes). The script prints a `run_id` — use it to
+download the adapter with [`modal volume get`](https://modal.com/docs/reference/cli/volume):
+
+```bash
+modal volume get tuft-checkpoints <run_id> ./weights/
+# -> ./weights/<run_id>/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
+```
+
+Optionally merge the adapter into full model weights (needs `torch`, `peft`, `transformers`):
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, "./weights/<run_id>/yoda-final/adapter").merge_and_unload()
+merged.save_pretrained("./yoda-merged")   # standard HF model dir, servable by vLLM
+```
+
+## Step 5 — Tear down
+
+If you deployed in the foreground, just press `Ctrl-C`. For a detached deploy:
+
+```bash
+python deploy/modal/launch.py --down --name tuft-yoda
+```
+
+With `min_containers: 0`, an idle Modal deployment already costs nothing, but `--down`
+removes the app entirely. Your adapters remain in the `tuft-checkpoints` Volume until you
+delete it.
+
+```{tip}
+Even with scale-to-zero, the GPU is **under-utilized** during an active session — the client
+waits between bursts. Because TuFT is multi-tenant, you can keep one warm deployment busy by
+pointing **several concurrent clients** at it (your own jobs or other users, each with a key
+under `authorized_users`; raise `max_loras` for more adapters at once). See
+[Keeping the GPU busy](index.md#keeping-the-gpu-busy).
+```
+
+## Next steps
+
+- Try a bigger model (e.g. `Qwen/Qwen3-4B`) by changing both names in the config and setting
+  `modal.gpu` to `H100` (or pass `--gpu H100`).
+- See the [Lambda Cloud guide](lambda.md) for a dedicated on-demand GPU VM instead.
+- Browse [Modal's docs](https://modal.com/docs) for GPU types, Volumes, and Secrets.

--- a/docs/sphinx_doc/source/getting-started/installation.md
+++ b/docs/sphinx_doc/source/getting-started/installation.md
@@ -2,6 +2,15 @@
 
 This guide covers different ways to install TuFT.
 
+```{admonition} 🚀 No GPU? No problem!
+:class: tip
+
+The instructions below assume a machine with a GPU. **No GPU?** You can deploy TuFT to a
+pay-as-you-go cloud provider — **[Modal](../deployment/modal.md)** (serverless,
+scale-to-zero) or **[Lambda Cloud](../deployment/lambda.md)** — and fine-tune from your
+laptop. See the **[Deployment guides](../deployment/index.md)**.
+```
+
 ## Quick Install
 
 > **Note**: This script supports unix platforms. For other platforms, see the manual installation sections below.

--- a/docs/sphinx_doc/source/index.md
+++ b/docs/sphinx_doc/source/index.md
@@ -32,11 +32,21 @@ sd_hide_title: true
   <a class="quickstart-cta-link" href="getting-started/quickstart.html">Quickstart →</a>
 </div>
 
+```{admonition} 🚀 No GPU? No problem!
+:class: tip
+
+You don't need to own a GPU to run TuFT. Deploy it to a pay-as-you-go cloud provider —
+**[Modal](deployment/modal.md)** (serverless, scale-to-zero) or
+**[Lambda Cloud](deployment/lambda.md)**, then fine-tune from your laptop.
+See the **[Deployment guides](deployment/index.md)**.
+```
+
 ```{toctree}
 :maxdepth: 2
 :hidden:
 
 getting-started/index
+deployment/index
 user-guide/index
 development/index
 roadmap

--- a/docs/sphinx_doc/source_zh/deployment/index.md
+++ b/docs/sphinx_doc/source_zh/deployment/index.md
@@ -1,0 +1,66 @@
+# 部署
+
+```{admonition} 🚀 没有 GPU？没问题！
+:class: tip
+
+运行 TuFT 并不需要你自己拥有 GPU。这些指南将展示如何在**按量付费的云服务商**上搭建一个 TuFT
+服务器——按需租用 GPU，用完即释放。只需将
+[Tinker](https://github.com/thinking-machines-lab/tinker) SDK 指向云端服务器，即可在本地（笔记本，无本地 GPU）驱动训练。
+```
+
+TuFT 是一个单一、标准的服务器（`tuft launch`）。
+[`deploy/`](https://github.com/agentscope-ai/TuFT/tree/main/deploy) 目录下的部署辅助工具只是
+在租用的算力上运行这个完全相同的服务器，并为你接好存储、端口和密钥——
+它们不会改变产品本身的任何东西。请选择适合你工作流程的后端：
+
+```{grid} 1 2 2 2
+:gutter: 3
+
+:::{grid-item-card} Modal
+:link: modal
+:link-type: doc
+:shadow: none
+
+**无服务器（Serverless），缩容至零。** 部署一个 Web 端点，空闲时缩容至零，
+按秒计费。适合突发或间歇性的使用场景。
+:::
+
+:::{grid-item-card} Lambda Cloud
+:link: lambda
+:link-type: doc
+:shadow: none
+
+**一台普通的按需 GPU 虚拟机**，按分钟计费，直到你将其终止为止。没有编排层；
+实例会一直运行，直到你将它停止。
+:::
+```
+
+## 我应该选择哪一个？
+
+| 如果你想要…… | 使用 | 说明 |
+|---|---|---|
+| 空闲时缩容至零 | **[Modal](modal.md)** | 无服务器（Serverless）；缩容至零、按秒计费、托管代理与卷（Volume）。 |
+| 一个单独的专用 GPU 实例 | **[Lambda Cloud](lambda.md)** | 按需、按分钟计费，直到你将其终止；没有编排层，也没有抢占。 |
+
+(keeping-the-gpu-busy)=
+## 保持 GPU 繁忙
+
+单个由笔记本驱动的训练运行会让租用的 GPU **利用率不足**：客户端要做数据分词、
+构建批次，并在多次 GPU 计算突发之间等待 HTTP 往返，因此 GPU 在大部分运行时间里都处于空闲状态。由于 TuFT 是
+**多租户**的，一个已部署的服务器可以在同一块 GPU 上承载**多个并发的任务或用户**——
+在 `authorized_users` 下为每个人分配各自的密钥，并调高 `max_loras`，使多个 LoRA 适配器可以同时训练。以这种方式共享
+能提升利用率并分摊成本。这在 **Lambda** 上最为重要（无论 GPU 是否在工作都会持续计费），
+在活跃的 **Modal** 会话期间也很重要（容器处于热状态，但 GPU 的使用是突发的）。
+
+两份指南都会带你走完**同一个端到端示例**：配置服务器、
+部署服务器、在本地（笔记本）上为 `Qwen/Qwen3-0.6B` 训练一个“像 Yoda 一样说话”的 LoRA，并
+下载训练好的适配器——全部复用
+[`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft) 中可直接运行的代码。
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+modal
+lambda
+```

--- a/docs/sphinx_doc/source_zh/deployment/lambda.md
+++ b/docs/sphinx_doc/source_zh/deployment/lambda.md
@@ -1,0 +1,250 @@
+# 在 Lambda Cloud 上部署
+
+[Lambda Cloud](https://lambda.ai) 提供普通的按需 GPU 虚拟机，按分钟计费，直到你终止它们——没有编排层，也没有抢占。本指南将带你完成端到端的流程——配置一个 TuFT 服务器，在 Lambda GPU 上启动它，在本地（笔记本）上基于 `Qwen/Qwen3-0.6B` 训练一个"像 Yoda 一样说话"的 LoRA，并下载该适配器——**无需本地 GPU**。
+
+```{admonition} 你将构建的内容
+:class: note
+
+一个运行在 Lambda GPU 虚拟机上的 TuFT 服务器（通过 Docker 自动置备并自我引导），你可以通过 SSH 隧道连接它，并使用 [`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft) 中的可运行代码在本地（笔记本）上对其进行微调。
+```
+
+```{admonition} Lambda 没有缩容至零
+:class: warning
+
+与 Modal 不同，Lambda 虚拟机会**持续计费，直到你终止它**——没有空闲/自动停止。完成后务必销毁（终止）实例（参见 [第 5 步](#step-5-tear-down)）。
+```
+
+## 准备工作
+
+1. **一个 Lambda Cloud 账户、API key 和 SSH key。** 在
+   [Lambda Cloud 控制台](https://cloud.lambda.ai)中，生成一个 API key
+   （[API keys](https://cloud.lambda.ai/api-keys)）并注册一个 SSH 公钥
+   （[SSH keys](https://cloud.lambda.ai/ssh-keys)）——你将使用匹配的私钥来连接服务器。详情请参阅 Lambda 的[文档](https://docs.lambda.ai)。导出 API key，以便启动器能够找到它：
+
+   ```bash
+   export LAMBDA_API_KEY=secret_...
+   ```
+
+2. **TuFT 仓库。** 部署辅助脚本与 Lambda 的 HTTP API 通信；它在本地只需要 `pyyaml`（所有 GPU 依赖都在虚拟机上的容器内运行）：
+
+   ```bash
+   git clone https://github.com/agentscope-ai/TuFT
+   cd TuFT
+   pip install pyyaml
+   ```
+
+## 第 1 步 —— 配置服务器
+
+部署辅助脚本 [`deploy/lambda/launch.py`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/lambda/launch.py)
+是**配置文件驱动**的，并与 Modal 启动器保持一致：你编辑一个标准的
+`tuft_config.yaml` 并运行该脚本。Lambda 基础设施配置放在一个可选的 `lambda:` 小节中，该小节会在服务器看到之前被剥离。
+
+将以下内容保存为 `yoda_lambda.yaml`：
+
+```yaml
+checkpoint_dir: ~/.cache/tuft/checkpoints   # mapped to the VM's /data; see Step 4 about durability
+model_owner: cloud-user
+
+supported_models:
+  - model_name: Qwen/Qwen3-0.6B
+    model_path: Qwen/Qwen3-0.6B            # HF id (downloaded on first launch) or a local path
+    max_model_len: 4096
+    tensor_parallel_size: 1
+    colocate: true                         # single GPU: training + vLLM sampling share it
+    sampling_memory_fraction: 0.4
+    max_lora_rank: 16
+    max_loras: 2
+
+authorized_users:
+  tml-REPLACE_WITH_A_STRONG_KEY: cloud-user  # clients send this as the X-API-Key header
+
+persistence:
+  mode: DISABLE
+
+telemetry:
+  enabled: false
+
+# Lambda Cloud infra for deploy/lambda/launch.py (TuFT ignores this; it's stripped before the server sees it):
+lambda:
+  gpu: a100              # family hint; auto-pick prefers a100
+  name: tuft-yoda
+  # ssh_key: my-key      # default: your account's sole registered key
+  # filesystem: tuft     # Lambda persistent filesystem for durable checkpoints (else ephemeral root disk)
+```
+
+为 `authorized_users` 生成一个真实的 API key（它**必须**以 `tml-` 开头）：
+
+```bash
+python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+```
+
+```{admonition} 训练请选择 a100，而不是 a10
+:class: warning
+
+最便宜的 Lambda GPU（`gpu_1x_a10`，sm_86）在当前的 TuFT 镜像中有一个已知问题：
+**服务可以正常工作，但训练会返回 null logprobs**。因此自动选择会**优先选择
+a100**，仅在万不得已时才使用 a10。对于本训练示例，请坚持使用 a100。
+```
+
+## 第 2 步 —— 启动 GPU 服务器
+
+运行启动器。在未指定实例的情况下，它会自动选择与你的 `gpu:` 提示相匹配、可用且最便宜的 GPU，对其进行置备，并通过 cloud-init 在 Docker 中自我引导 TuFT（无需手动 SSH）：
+
+```bash
+python deploy/lambda/launch.py --config yoda_lambda.yaml
+```
+
+它会打印所选择的实例，并在虚拟机启动后打印一条连接横幅，其中包含一条 SSH 隧道命令和实例 id：
+
+```text
+[launch] gpu_1x_a100_sxm4 in us-east-1 (~$1.99/hr), ssh_key=my-key, name=tuft-yoda
+[launch] provisioning instance abcd...  (this takes a minute)
+[launch] instance abcd1234... is active at 203.0.113.45
+
+Connect securely over an SSH tunnel (recommended; keeps :10610 off the public net):
+    ssh -N -L 10610:localhost:10610 ubuntu@203.0.113.45
+```
+
+```{tip}
+你可以随时使用 `python deploy/lambda/launch.py --status` 检查或列出实例。要复用某个现有实例而不是启动新实例，请传入 `--instance-id <id>`。
+```
+
+## 第 3 步 —— 在本地（笔记本）上训练 Yoda LoRA
+
+在一个终端中打开上面打印的 SSH 隧道（首次启动会拉取镜像并加载 vLLM，这可能需要几分钟）：
+
+```bash
+ssh -N -L 10610:localhost:10610 ubuntu@203.0.113.45
+```
+
+```{note}
+训练仍然运行**在你的笔记本上**——`train.py` 是一个仅使用 CPU 的客户端，它通过 HTTP 驱动训练循环。`-L 10610:localhost:10610` 标志会把你笔记本的 `10610` 端口转发到虚拟机上服务器的 `10610` 端口，因此 `http://localhost:10610`（下面会用到）只是隧道的*本地端*：每个请求都会通过 SSH 传送到**远程 GPU**，训练和采样实际就在那里运行。请在整个运行过程中保持这个 SSH 终端打开。（不想使用隧道？你也可以直接将 `--base-url` 指向 `http://<vm-ip>:10610`，但这会把 API 暴露在公共互联网上。）
+```
+
+在第二个终端中，通过隧道确认服务器健康：
+
+```bash
+curl http://localhost:10610/api/v1/healthz
+# {"status":"ok"}
+```
+
+训练脚本 [`examples/personality_sft/train.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/train.py)
+是一个**客户端**，它通过 Tinker SDK 经由 HTTP 驱动训练循环——它只需要 CPU 端的依赖：
+
+```bash
+pip install tinker transformers
+```
+
+数据集是
+[`dataset.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/dataset.py)
+中约 50 对手工编写的 `(user, assistant-in-Yoda-voice)` 配对。只有**助手**的 token 获得损失权重（提示词被掩码），因此模型学习的是*语气*，而不是问题本身。这里给出几个示例配对：
+
+```python
+YODA_PAIRS = [
+    (
+        "How do I stay motivated?",
+        "Motivated, you wish to stay? Hmm. Small steps each day, take you must. "
+        "Begin, and momentum follows. Do or do not — there is no try.",
+    ),
+    (
+        "What's the best way to learn programming?",
+        "Patient you must be, young one. Write code daily, you should. "
+        "Fail often, learn faster you will. Much to learn, you still have.",
+    ),
+    # ... ~50 pairs total
+]
+```
+
+将脚本指向隧道（`http://localhost:10610`），传入 `tml-` key，并选择模型（它必须与服务器上的 `supported_models` 条目相匹配）：
+
+```bash
+python examples/personality_sft/train.py \
+    --base-url http://localhost:10610 \
+    --api-key tml-REPLACE_WITH_A_STRONG_KEY \
+    --model Qwen/Qwen3-0.6B
+```
+
+脚本会在训练**之前**对基础模型采样，运行 60 个 LoRA 步骤，然后在训练**之后**对训练好的适配器采样，这样你就能看到个性逐渐显现：
+
+```text
+[before] sampling base model on held-out prompts
+   [base] Give me advice on becoming a better person.
+      -> Focus on small consistent habits: be honest, listen to others, and learn from your mistakes.
+   [base] What's the key to writing good software?
+      -> Keep it readable and well-tested, prefer small functions, and document your intent.
+
+[train] 60 steps, batch 8, lr 0.0001, rank 16
+   step   0  loss=2.3987
+   step  10  loss=1.7765
+   step  50  loss=1.2410
+   step  59  loss=1.1702
+
+[save] sampler=tinker://abcd1234.../yoda-sampler
+[save] run_id=abcd1234-...
+
+[after] sampling the trained adapter
+   [yoda] Give me advice on becoming a better person.
+      -> Small steps each day, take you must. Honest, be. Listen more than speak, you should. Grow, you will, hmm.
+   [yoda] What's the key to writing good software?
+      -> Simple, keep it, you must. Read aloud your code, you should. Fail often, learn faster you will, young one.
+```
+
+```{tip}
+可调参数：`--lora-rank`、`--num-steps`、`--batch-size`、`--learning-rate`、`--max-length`。
+传入 `--no-before` 可跳过基础模型采样。编辑 `dataset.py` 即可换成不同的角色。
+```
+
+## 第 4 步 —— 下载适配器
+
+训练会向服务器的 `checkpoint_dir` 写入一个标准的 [PEFT](https://huggingface.co/docs/peft) LoRA 适配器，在虚拟机上它位于 `/home/ubuntu/tuft-data/checkpoints` 下。脚本会打印一个 `run_id`——用 `scp` 把适配器从实例上拷贝下来：
+
+```bash
+scp -r ubuntu@203.0.113.45:/home/ubuntu/tuft-data/checkpoints/<run_id> ./weights/
+# -> ./weights/<run_id>/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
+```
+
+```{admonition} 在终止之前先下载
+:class: warning
+
+默认情况下，检查点位于实例的**临时根磁盘**上——终止虚拟机（第 5 步）会销毁它们。请**先下载**，或者使用持久化的 `filesystem:`（一个 [Lambda filesystem](https://docs.lambda.ai)）启动，这样检查点就能在终止后保留下来。
+```
+
+可选：将适配器合并到完整的模型权重中（需要 `torch`、`peft`、`transformers`）：
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, "./weights/<run_id>/yoda-final/adapter").merge_and_unload()
+merged.save_pretrained("./yoda-merged")   # standard HF model dir, servable by vLLM
+```
+
+(step-5-tear-down)=
+## 第 5 步 —— 销毁（终止）
+
+Lambda 会一直计费直到你终止，所以完成后请务必关闭实例：
+
+```bash
+python deploy/lambda/launch.py --down --instance-id abcd1234...
+# or by name:
+python deploy/lambda/launch.py --down --name tuft-yoda
+```
+
+确认没有任何东西仍在运行：
+
+```bash
+python deploy/lambda/launch.py --status
+```
+
+```{tip}
+Lambda 会持续对 GPU 计费，因此单个由笔记本驱动的运行**会为大量空闲时间付费**。由于 TuFT 是多租户的，你可以将**多个并发作业或用户**指向同一个实例（每个用户在 `authorized_users` 下都有一个 key；提高 `max_loras` 可同时支持更多适配器），以保持 GPU 繁忙并分摊成本。参见
+{ref}`保持 GPU 繁忙 <keeping-the-gpu-busy>`。
+```
+
+## 后续步骤
+
+- 通过更改配置中的两处名称来尝试更大的模型（例如 `Qwen/Qwen3-4B`）；自动选择的 a100（80 GB）有充裕的空间。
+- 更喜欢缩容至零的方案？参见 [Modal 指南](modal.md)。
+- 浏览 [Lambda 的文档](https://docs.lambda.ai)，了解实例类型、区域和文件系统。

--- a/docs/sphinx_doc/source_zh/deployment/modal.md
+++ b/docs/sphinx_doc/source_zh/deployment/modal.md
@@ -1,0 +1,230 @@
+# 在 Modal 上部署
+
+[Modal](https://modal.com) 是一个无服务器（Serverless）GPU 平台：你部署一个容器，它仅在有请求处理时才运行在 GPU 上，空闲时缩容至零。本指南将带你从头到尾完成整个流程——配置一个 TuFT 服务器、将其部署到 Modal、在本地（笔记本）驱动训练，在 `Qwen/Qwen3-0.6B` 上训练一个"像尤达大师那样说话"的 LoRA，并下载该适配器——而且**无需本地 GPU**。
+
+```{admonition} 你将构建的内容
+:class: note
+
+一个运行在 Modal L4 GPU 上的 TuFT 服务器，可通过一个公开的 `…modal.run` URL 访问；你将使用
+[`examples/personality_sft/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft)
+中的可运行代码在本地（笔记本）对其进行微调。
+```
+
+## 准备工作
+
+1. **一个 Modal 账户 + CLI。** 安装客户端并完成身份验证（这会打开浏览器以创建一个 API token——参见 Modal 的
+   [Getting started](https://modal.com/docs/guide) 和
+   [`modal token`](https://modal.com/docs/reference/cli/token) 文档）：
+
+   ```bash
+   pip install modal
+   modal token new
+   ```
+
+2. **TuFT 仓库。** 部署辅助脚本和训练示例都位于该仓库中；启动器本身在本地只需要 `modal` + `pyyaml`（繁重的 GPU 依赖运行在 Modal 的容器内部，而不是你的机器上）：
+
+   ```bash
+   git clone https://github.com/agentscope-ai/TuFT
+   cd TuFT
+   pip install modal pyyaml
+   ```
+
+`Qwen/Qwen3-0.6B` 是可公开下载的，因此不需要 Hugging Face token。对于**受限（gated）**模型，请创建一个保存有你的
+`HF_TOKEN` 的 [Modal Secret](https://modal.com/docs/guide/secrets)，并向启动器传入 `--hf-secret <secret-name>`。
+
+## 第 1 步 —— 配置服务器
+
+部署辅助脚本 [`deploy/modal/launch.py`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/modal/launch.py)
+是**由配置文件驱动**的：你编辑一个标准的 `tuft_config.yaml`（即 `tuft launch --config` 所使用的同一个文件）并运行该脚本。Modal 基础设施配置放在一个可选的 `modal:`
+区段中，该区段在服务器看到配置之前会被剥离掉。
+
+将以下内容保存为 `yoda_modal.yaml`：
+
+```yaml
+checkpoint_dir: ~/.cache/tuft/checkpoints   # on Modal, launch.py pins this to a Volume automatically
+model_owner: cloud-user
+
+supported_models:
+  - model_name: Qwen/Qwen3-0.6B
+    model_path: Qwen/Qwen3-0.6B            # HF id (downloaded on first launch) or a local path
+    max_model_len: 4096
+    tensor_parallel_size: 1
+    colocate: true                         # single GPU: training + vLLM sampling share it
+    sampling_memory_fraction: 0.4
+    max_lora_rank: 16
+    max_loras: 2
+
+authorized_users:
+  tml-REPLACE_WITH_A_STRONG_KEY: cloud-user  # clients send this as the X-API-Key header
+
+persistence:
+  mode: DISABLE
+
+telemetry:
+  enabled: false
+
+# Modal infra for deploy/modal/launch.py (TuFT ignores this; it's stripped before the server sees it):
+modal:
+  gpu: L4
+  name: tuft-yoda
+  proxy_auth: false      # the tml- API key is the auth; the Tinker SDK can't send Modal gateway headers
+  min_containers: 0      # scale to zero when idle
+```
+
+为 `authorized_users` 生成一个真实的 API key（它**必须**以 `tml-` 开头）：
+
+```bash
+python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+```
+
+```{tip}
+一个包含所有可用选项的现成示例位于
+[`deploy/modal/tuft_config.example.yaml`](https://github.com/agentscope-ai/TuFT/tree/main/deploy/modal/tuft_config.example.yaml)，
+而下文使用的示例自带其
+[`config.yaml`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/config.yaml)。
+```
+
+## 第 2 步 —— 部署到 Modal
+
+在**前台**运行启动器，这样当你按下 `Ctrl-C` 时服务器会被自动销毁（终止）：
+
+```bash
+python deploy/modal/launch.py --config yoda_modal.yaml --foreground
+```
+
+该脚本会生成一个自包含的 Modal 应用（一个
+[`@modal.web_server`](https://modal.com/docs/guide/webhooks)）并将其提供出去。它会打印一个公开的 URL——把它复制下来：
+
+```text
+✓ Created web endpoint => https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run
+```
+
+确认服务器已启动（健康检查路由无需鉴权；首次调用会冷启动镜像并加载 vLLM，这可能需要几分钟）：
+
+```bash
+curl https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run/api/v1/healthz
+# {"status":"ok"}
+```
+
+**部署模式。** `--foreground`（此处使用）封装了 `modal serve`——适合交互式运行；按 `Ctrl-C` 即可停止。省略它则为**分离式（detached）**部署（`modal deploy`），它会一直运行，直到你用 `--down` 将其停止：
+
+```bash
+python deploy/modal/launch.py --config yoda_modal.yaml          # detached
+python deploy/modal/launch.py --down --name tuft-yoda           # stop it later
+```
+
+`checkpoint_dir` 会被自动绑定到一个 [Modal Volume](https://modal.com/docs/guide/volumes)
+（`tuft-checkpoints`），这样你的适配器在容器关闭后仍能保留下来。
+
+## 第 3 步 —— 在本地（笔记本）训练 Yoda LoRA
+
+训练脚本 [`examples/personality_sft/train.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/train.py)
+是一个**客户端**，它通过 Tinker SDK 经由 HTTP 连接到运行中的服务器——只需要 CPU 侧的依赖：
+
+```bash
+pip install tinker transformers
+```
+
+数据集是约 50 对手工编写的 `(user, assistant-in-Yoda-voice)` 配对，位于
+[`dataset.py`](https://github.com/agentscope-ai/TuFT/tree/main/examples/personality_sft/dataset.py)
+中。只有**助手**的 token 会获得损失权重（提示词被掩码），因此模型学习的是*语气*，而非问题本身。下面是几个示例配对：
+
+```python
+YODA_PAIRS = [
+    (
+        "How do I stay motivated?",
+        "Motivated, you wish to stay? Hmm. Small steps each day, take you must. "
+        "Begin, and momentum follows. Do or do not — there is no try.",
+    ),
+    (
+        "What's the best way to learn programming?",
+        "Patient you must be, young one. Write code daily, you should. "
+        "Fail often, learn faster you will. Much to learn, you still have.",
+    ),
+    # ... ~50 pairs total
+]
+```
+
+将脚本指向你的 Modal URL，传入 `tml-` key，并选择模型（它必须与服务器上的 `supported_models` 条目匹配）：
+
+```bash
+python examples/personality_sft/train.py \
+    --base-url https://<your-workspace>--tuft-yoda-tuftserver-serve.modal.run \
+    --api-key tml-REPLACE_WITH_A_STRONG_KEY \
+    --model Qwen/Qwen3-0.6B
+```
+
+该脚本会在训练**之前**对基础模型进行采样，运行 60 个 LoRA 步骤，然后在训练**之后**对训练好的适配器进行采样，这样你就能看到这种个性逐渐浮现：
+
+```text
+[before] sampling base model on held-out prompts
+   [base] How should I spend my weekend?
+      -> You could relax, catch up on friends, or work on a hobby. Try to balance rest with something fun.
+   [base] I'm nervous about starting a new job.
+      -> That's normal. Prepare a little, get good sleep, and remember they hired you for a reason.
+
+[train] 60 steps, batch 8, lr 0.0001, rank 16
+   step   0  loss=2.4131
+   step  10  loss=1.8027
+   step  50  loss=1.2563
+   step  59  loss=1.1894
+
+[save] sampler=tinker://abcd1234.../yoda-sampler
+[save] run_id=abcd1234-...
+
+[after] sampling the trained adapter
+   [yoda] How should I spend my weekend?
+      -> Rest and adventure, balance them you must, hmm. Outside, go — the Force in nature lives. Restored, you will be.
+   [yoda] I'm nervous about starting a new job.
+      -> Nervous, you are? Natural, this fear is. Breathe, you must. Chosen, you were — trust yourself, young one.
+```
+
+```{tip}
+可调参数：`--lora-rank`、`--num-steps`、`--batch-size`、`--learning-rate`、`--max-length`。
+传入 `--no-before` 可跳过对基础模型的采样。编辑 `dataset.py` 即可换成另一个角色。
+```
+
+## 第 4 步 —— 下载适配器
+
+训练会将一个标准的 [PEFT](https://huggingface.co/docs/peft) LoRA 适配器写入服务器的 `checkpoint_dir`，在 Modal 上即
+`tuft-checkpoints` [Volume](https://modal.com/docs/guide/volumes)。该脚本会打印一个 `run_id`——用它通过
+[`modal volume get`](https://modal.com/docs/reference/cli/volume) 下载适配器：
+
+```bash
+modal volume get tuft-checkpoints <run_id> ./weights/
+# -> ./weights/<run_id>/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
+```
+
+你也可以选择将适配器合并进完整的模型权重中（需要 `torch`、`peft`、`transformers`）：
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, "./weights/<run_id>/yoda-final/adapter").merge_and_unload()
+merged.save_pretrained("./yoda-merged")   # standard HF model dir, servable by vLLM
+```
+
+## 第 5 步 —— 销毁（终止）
+
+如果你是在前台部署的，只需按 `Ctrl-C` 即可。对于分离式部署：
+
+```bash
+python deploy/modal/launch.py --down --name tuft-yoda
+```
+
+由于设置了 `min_containers: 0`，一个空闲的 Modal 部署本就不产生任何费用，但 `--down` 会将该应用彻底移除。你的适配器会一直保留在 `tuft-checkpoints` Volume 中，直到你将其删除。
+
+```{tip}
+即便采用了缩容至零，在一次活跃会话期间 GPU 仍然**利用率不足**——客户端在两次突发请求之间处于等待状态。由于 TuFT 是多租户的，你可以通过将**多个并发客户端**指向同一个热部署来让它保持繁忙（无论是你自己的任务还是其他用户的任务，每个都在 `authorized_users` 下持有一个 key；提高 `max_loras` 以同时容纳更多适配器）。参见
+{ref}`保持 GPU 繁忙 <keeping-the-gpu-busy>`。
+```
+
+## 后续步骤
+
+- 尝试一个更大的模型（例如 `Qwen/Qwen3-4B`），方法是同时更改配置中的两个名称，并将
+  `modal.gpu` 设为 `H100`（或传入 `--gpu H100`）。
+- 如果你想要一个专用的按需 GPU 虚拟机，请参见 [Lambda Cloud 指南](lambda.md)。
+- 浏览 [Modal 的文档](https://modal.com/docs) 以了解 GPU 类型、Volume 和 Secret。

--- a/docs/sphinx_doc/source_zh/getting-started/installation.md
+++ b/docs/sphinx_doc/source_zh/getting-started/installation.md
@@ -2,6 +2,15 @@
 
 本指南介绍安装 TuFT 的不同方式。
 
+```{admonition} 🚀 没有 GPU？没问题！
+:class: tip
+
+下面的说明假设你的机器配有 GPU。**没有 GPU？** 你可以将 TuFT 部署到按量付费的云服务商——
+**[Modal](../deployment/modal.md)**（无服务器，缩容至零）或
+**[Lambda Cloud](../deployment/lambda.md)**——然后在本地（笔记本）驱动微调。
+参阅 **[部署指南](../deployment/index.md)**。
+```
+
 ## 快速安装
 
 > **注意**：此脚本支持 Unix 平台。其他平台请参阅下面的手动安装部分。

--- a/docs/sphinx_doc/source_zh/index.md
+++ b/docs/sphinx_doc/source_zh/index.md
@@ -32,11 +32,21 @@ sd_hide_title: true
   <a class="quickstart-cta-link" href="getting-started/quickstart.html">快速开始 →</a>
 </div>
 
+```{admonition} 🚀 没有 GPU？没问题！
+:class: tip
+
+运行 TuFT 无需自备 GPU。将其部署到按量付费的云服务商——
+**[Modal](deployment/modal.md)**（无服务器，缩容至零）或
+**[Lambda Cloud](deployment/lambda.md)**，然后在本地（笔记本）驱动微调。
+参阅 **[部署指南](deployment/index.md)**。
+```
+
 ```{toctree}
 :maxdepth: 2
 :hidden:
 
 getting-started/index
+deployment/index
 user-guide/index
 development/index
 roadmap

--- a/examples/personality_sft/README.md
+++ b/examples/personality_sft/README.md
@@ -61,8 +61,8 @@ The LoRA adapter + sampler weights are saved on the **server's** `checkpoint_dir
 that's a Volume — download the standard PEFT adapter (the `run_id` is printed at the end):
 
 ```bash
-modal volume get tuft-lora-checkpoints <run_id> ./weights/
-# -> ./weights/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
+modal volume get tuft-checkpoints <run_id> ./weights/
+# -> ./weights/<run_id>/yoda-final/adapter/{adapter_config.json, adapter_model.safetensors}
 ```
 
 **Merge into full model weights** (optional; needs `torch`, `peft`, `transformers`):

--- a/examples/personality_sft/train.py
+++ b/examples/personality_sft/train.py
@@ -169,7 +169,7 @@ def main() -> None:
 
     print("\n✅ Done. The LoRA adapter + sampler weights live on the server's checkpoint_dir.")
     print("   On Modal, download the adapter with:")
-    print(f"       modal volume get tuft-lora-checkpoints {run_id} ./weights/")
+    print(f"       modal volume get tuft-checkpoints {run_id} ./weights/")
     print("   (see examples/personality_sft/README.md to merge it into full model weights)")
 
 


### PR DESCRIPTION
## Summary

Adds a **Deployment** section to the documentation site, covering how to run TuFT on
pay-as-you-go cloud GPUs with no local GPU. Each guide is end-to-end and reuses the runnable
code in `examples/personality_sft/`.

## What's included

**New docs (`docs/sphinx_doc/source/deployment/`):**

| Page | Contents |
|---|---|
| `index.md` | Lists the deployment options with a brief description, a "which one should I pick?" table, and a **Keeping the GPU busy** note on utilization + multi-tenant sharing. |
| `modal.md` | End-to-end [Modal](https://modal.com) guide: configure the server (`Qwen/Qwen3-0.6B`), deploy, train a "talk like Yoda" LoRA from your laptop (with sample training data and before/after outputs), and download the adapter. References Modal's docs for provider-specific steps. |
| `lambda.md` | The same flow on [Lambda Cloud](https://lambda.ai): launch a GPU VM, reach it over an SSH tunnel, train from your laptop, and download the adapter (with a note clarifying the client/server split and tunnel). |

**Wiring + entry points:**

- Registered the section in the homepage `toctree`, and added a "No GPU? No problem!" notice to the docs **homepage** and **installation page** linking to the guides.
- Added a **Deployment** section to `README.md` (after "Use the Pre-built Docker Image") with a table linking to the online guides, plus the same notice near the top and a table-of-contents entry.

**Drive-by fix:**

- Corrected the checkpoint Volume name in the `personality_sft` example (`tuft-lora-checkpoints` → `tuft-checkpoints`) so the documented `modal volume get` command matches the deploy default and actually works.

## Notes

- English `source/` only; the `source_zh/` mirror is unchanged.
- The Sphinx docs build cleanly (0 warnings).
