### PR TITLE
Add on-policy distillation example and user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ We provide practical examples and comprehensive guides for using TuFT. For full 
 |---|---|
 | [Chat SFT](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/chat-sft.html) | Supervised fine-tuning on chat-formatted data with assistant-only loss masking. [Notebook](examples/chat_sft/chat_sft.ipynb) |
 | [Countdown RL](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/countdown-rl.html) | Reinforcement learning with GRPO-style training on verifiable tasks. [Notebook](examples/countdown_rl/countdown_rl.ipynb) |
+| [On-Policy Distillation](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/on-policy-distillation.html) | Distill a teacher into a student on the student's own samples via per-token reverse-KL. [Example](examples/on_policy_distillation/) |
 | [Persistence](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/persistence.html) | Optional Redis-based server state persistence for crash recovery. |
 | [Observability](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/telemetry.html) | OpenTelemetry integration for tracing, metrics, and logs. |
 | [Console](https://agentscope-ai.github.io/TuFT/en/latest/user-guide/console.html) | Dashboard for monitoring training runs, checkpoints, and sampling playground. |

--- a/docs/sphinx_doc/source/user-guide/index.md
+++ b/docs/sphinx_doc/source/user-guide/index.md
@@ -21,6 +21,14 @@ Supervised fine-tuning on chat-formatted data with assistant-only loss masking.
 Reinforcement learning with GRPO-style training on verifiable tasks.
 :::
 
+:::{grid-item-card} On-Policy Distillation
+:link: on-policy-distillation
+:link-type: doc
+:shadow: none
+
+Distill a teacher into a student on the student's own samples, via per-token reverse-KL.
+:::
+
 :::{grid-item-card} Persistence
 :link: persistence
 :link-type: doc
@@ -52,6 +60,7 @@ Dashboard for monitoring training runs, checkpoints, and sampling playground.
 
 chat-sft
 countdown-rl
+on-policy-distillation
 persistence
 telemetry
 console

--- a/docs/sphinx_doc/source/user-guide/on-policy-distillation.md
+++ b/docs/sphinx_doc/source/user-guide/on-policy-distillation.md
@@ -1,0 +1,388 @@
+# On-Policy Distillation (OPD)
+
+This guide demonstrates **on-policy distillation (OPD)** — training a *student* model to match a
+*teacher's* per-token distribution **on the student's own samples** — using a **running TuFT server**.
+Full runnable code is in [`examples/on_policy_distillation/`](https://github.com/agentscope-ai/TuFT/tree/main/examples/on_policy_distillation)
+(`train.py`, `dataset.py`, `config.yaml`). Although this is a general OPD guide, it also documents the
+practical details (teacher log-probs, the reverse-KL advantage, single- vs multi-GPU hosting) needed to
+run it end-to-end on TuFT.
+
+OPD is the recipe from Thinking Machines' [*On-Policy Distillation*](https://thinkingmachines.ai/blog/on-policy-distillation/).
+It combines the **dense, per-token supervision** of distillation (every token gets a signal, unlike RL's
+single scalar reward) with **on-policy sampling** (the student learns on its own trajectories, unlike
+off-policy SFT, which suffers from compounding error). On TuFT it reuses the **exact same machinery as RL**:
+the `importance_sampling` loss, with a per-token advantage set to the teacher–student log-prob gap.
+
+---
+
+## What You'll Learn
+
+1. What **on-policy distillation** is, and when to reach for it over **SFT** or **RL**
+2. How to get a **teacher's per-token log-probs** over the student's tokens with `compute_logprobs`
+3. How the **per-token reverse-KL advantage** (`teacher_logprob − student_logprob`) maps onto the `importance_sampling` loss
+4. How to run an end-to-end OPD loop on TuFT (sample → score → advantage → `forward_backward` → `optim_step`)
+5. How to host the teacher and student, and why a real **capability gap** (not just model size) is what makes OPD pay off
+
+---
+
+## Table of Contents
+1. [When to Use OPD vs. SFT vs. RL](#when-to-use-opd-vs-sft-vs-rl)
+2. [The Task](#the-task)
+3. [Minimal Training Example (OPD)](#minimal-training-example-opd)
+4. [Key Concepts](#key-concepts)
+   - [The OPD Loop](#the-opd-loop)
+   - [Teacher Log-probs via `compute_logprobs`](#teacher-log-probs-via-compute_logprobs)
+   - [The Per-Token Reverse-KL Advantage](#the-per-token-reverse-kl-advantage)
+   - [Datum Format for OPD](#datum-format-for-opd)
+   - [Hosting](#hosting)
+5. [Results](#results)
+6. [Parameter Selection](#parameter-selection)
+7. [Q&A](#qa)
+
+---
+
+## When to Use OPD vs. SFT vs. RL
+
+| Topic | SFT | RL | On-Policy Distillation |
+|---|---|---|---|
+| Training signal | Gold target tokens | One scalar reward per rollout | Teacher's full distribution at **every** token |
+| Data sampled from | A fixed dataset (off-policy) | The student (on-policy) | The student (on-policy) |
+| You need | Curated answers | A reward / verifier | A stronger (or better-prompted) **teacher** |
+| Bits of feedback / sequence | O(N) but off-policy | O(1) | **O(N) and on-policy** |
+| Failure mode it avoids | — | Sparse, slow credit assignment | SFT's compounding error on unseen states |
+
+**Rule of thumb.** Reach for OPD when you have a **teacher you trust** (a larger model, or the same model
+under a richer prompt) and want the student to internalize its behavior **cheaply** — OPD is reported to
+reach RL-level results at a fraction of the compute because every token carries signal. It pairs naturally
+*after* SFT and as a cheaper alternative to RL when a teacher is available.
+
+---
+
+## The Task
+
+We use **[GSM8K](https://huggingface.co/datasets/openai/gsm8k)** grade-school math word problems.
+
+| Role | Prompt it sees | Behavior |
+|---|---|---|
+| **Teacher** | system instruction **+ 4 worked few-shot examples** + the question | Reasons step by step, ends with `#### <number>` |
+| **Student** | just the question (bare) | Trained via OPD to match the teacher |
+
+In the default config the teacher **is the same base model** as the student — its only advantage is the
+few-shot prompt. OPD distills that *context* into the student's LoRA, so afterward the student reasons with
+the teacher's quality and concision **without any examples in its prompt**. This is "context distillation," and
+because there is only one set of base weights it fits on **one cheap GPU**.
+
+The only difference between the two prompts is the few-shot block (`dataset.py`):
+
+```python
+def student_prompt_ids(tokenizer, question):           # bare
+    messages = [{"role": "system", "content": STUDENT_SYSTEM},
+                {"role": "user", "content": question}]
+    return _render_ids(tokenizer, messages)
+
+def teacher_prompt_ids(tokenizer, question):           # + few-shot worked examples
+    messages = [{"role": "system", "content": TEACHER_SYSTEM}]
+    for q, a in FEWSHOT:
+        messages += [{"role": "user", "content": q}, {"role": "assistant", "content": a}]
+    messages.append({"role": "user", "content": question})
+    return _render_ids(tokenizer, messages)
+```
+
+---
+
+## Minimal Training Example (OPD)
+
+The experiments below ran on a **single NVIDIA A100-40GB** on [Modal](../deployment/modal.md)
+(teacher == student base model, `colocate: true`; a 24GB L4 also works with lighter batch/group).
+Before running, stand up a server with
+[`examples/on_policy_distillation/config.yaml`](https://github.com/agentscope-ai/TuFT/blob/main/examples/on_policy_distillation/config.yaml).
+
+The whole loop uses three TuFT calls you already know from the RL guide — `sample`, `compute_logprobs`,
+and `forward_backward(..., loss_fn="importance_sampling")`:
+
+```python
+import tinker
+from tinker import types
+
+client = tinker.ServiceClient(base_url="http://localhost:10610", api_key=TINKER_API_KEY)
+
+# Teacher = base model conditioned on a few-shot prompt (frozen; used only to score).
+teacher = client.create_sampling_client(base_model=BASE_MODEL)
+
+# Student = a LoRA we train.
+training = client.create_lora_training_client(
+    base_model=BASE_MODEL, rank=LORA_RANK,
+    train_mlp=True, train_attn=True, train_unembed=True,
+)
+```
+
+---
+
+## Key Concepts
+
+### The OPD Loop
+
+Each step is fully **on-policy**: sync the latest student weights to a sampler, let the student answer its
+own bare prompts, then ask the teacher how it would have scored those exact tokens.
+
+```python
+for step in range(NUM_STEPS):
+    # 1. On-policy: sample from the CURRENT student.
+    student_path = training.save_weights_for_sampler(name=f"opd-{step}").result().path
+    student_sampler = client.create_sampling_client(model_path=student_path)
+
+    datums = []
+    for problem in batch:
+        student_prompt = types.ModelInput.from_ints(student_prompt_ids(tok, problem.question))
+        res = student_sampler.sample(prompt=student_prompt, num_samples=GROUP,
+                                     sampling_params=types.SamplingParams(max_tokens=256, temperature=1.0)).result()
+
+        teacher_ids = teacher_prompt_ids(tok, problem.question)
+        for seq in res.sequences:
+            answer, student_lp = list(seq.tokens), list(seq.logprobs)
+
+            # 2. Teacher scores the student's EXACT tokens (see next section).
+            teacher_input = types.ModelInput.from_ints(teacher_ids + answer)
+            tlp = teacher.compute_logprobs(teacher_input).result()
+            p = len(teacher_ids)
+
+            # 3. Per-token reverse-KL advantage.
+            adv = [float(tlp[p + j]) - student_lp[j] for j in range(len(answer))]
+
+            datums.append(build_distillation_datum(
+                prompt=student_prompt, answer_tokens=answer,
+                sampling_logprobs=student_lp, advantages=adv))
+
+    # 4. One on-policy update.
+    training.forward_backward(datums, loss_fn="importance_sampling").result()
+    training.optim_step(types.AdamParams(learning_rate=1e-4)).result()
+```
+
+### Teacher Log-probs via `compute_logprobs`
+
+`compute_logprobs(prompt)` returns one log-prob per prompt token — `lp[i] = log P(token_i | token_0..i-1)`
+under that model. To score the **student's** answer under the **teacher**, concatenate the teacher's context
+with the student's sampled token IDs (no re-tokenization — the IDs are reused verbatim) and slice out the
+answer region:
+
+```text
+teacher_input = [ teacher_context (P tokens) ][ student_answer (T tokens) ]
+                                                ^
+teacher_logprob[j] = compute_logprobs(teacher_input)[P + j]      # aligns with student_logprob[j]
+```
+
+Position `P + j` is the teacher's log-prob of the student's `j`-th answer token, given the teacher's
+few-shot context — exactly aligned with `seq.logprobs[j]` from sampling, which is the student's own
+log-prob of the same token.
+
+### The Per-Token Reverse-KL Advantage
+
+Setting `advantage[t] = teacher_logprob[t] − student_logprob[t]` is the **single-sample estimator of the
+negative per-token reverse-KL** `−KL(student ‖ teacher)`: in expectation over the student's samples it equals
+`teacher − student` averaged under the student, which is `−D_KL` at that position. Plugged into the
+`importance_sampling` loss
+
+```text
+loss = − Σ_t  exp(target_logprob_t − sampling_logprob_t) · advantage_t
+```
+
+the gradient (the ratio is ≈ 1 right after sampling) is the REINFORCE update
+`−Σ_t advantage_t · ∇ log π_student(a_t)`: it **raises** the probability of tokens the teacher likes more than
+the student did, and **lowers** the others — pulling the student toward the teacher. This is the same loss the
+[Countdown RL guide](countdown-rl.md) uses; only the advantage differs (per-token KL instead of a reward).
+
+### Datum Format for OPD
+
+The `Datum` is built exactly like the RL example, but `advantages` is a **per-token list** (the KL signal)
+rather than one scalar per rollout. The prompt region is masked with zero advantage so only the answer
+tokens contribute (`dataset.py: build_distillation_datum`):
+
+```python
+model_input = prompt.append(types.EncodedTextChunk(tokens=answer_tokens[:-1]))
+ob_len = prompt.length - 1                       # prompt region: masked out
+
+loss_fn_inputs = {
+    "target_tokens": [0]*ob_len + answer_tokens,           # what the student must predict
+    "logprobs":      [0.0]*ob_len + sampling_logprobs,     # student's own sampling log-probs
+    "advantages":    [0.0]*ob_len + advantages,            # teacher_lp − student_lp per token
+}
+```
+
+The server computes the differentiable current-policy log-prob of `target_tokens`; `logprobs` is the
+constant sampling log-prob; `advantages` carries the distillation signal.
+
+### Hosting
+
+Because teacher and student are the **same base model**, this runs on **one GPU** with `colocate: true`
+(training and vLLM share it). A *different*, larger teacher can run on its own TuFT server — point `train.py`
+at it with `--teacher-model` / `--teacher-base-url` / `--teacher-api-key`.
+
+Before reaching for a bigger model, though, it's worth knowing that **OPD transfers capability, not just
+style** — so what makes it pay off is a real *per-token* capability gap between teacher and student, more than
+raw model size. A modest size bump on an easy task adds little signal (two strong same-family models mostly
+agree token-by-token; we found an 8B→1.7B teacher on GSM8K didn't beat this same-model few-shot setup). A
+bigger teacher helps when the gap is large and capability-relevant — a much weaker student, or a harder task
+like MATH/AIME, where the small model genuinely struggles. The same-model few-shot setup here is a reliable,
+cheap way to manufacture that gap.
+
+---
+
+## Results
+
+Qwen3-1.7B student, single A100-40GB, **16 steps** (batch 8 × group 4), `lr=1e-4`, rank 16, evaluated
+greedily on 100 held-out GSM8K problems:
+
+| | Accuracy | Prompt sees | Reasoning style |
+|---|---|---|---|
+| Bare student (before) | **63%** | just the question | verbose, headers, rarely a clean final line |
+| After OPD (bare prompt) | **72%** | just the question | concise teacher-style steps |
+| Few-shot teacher (ceiling) | 72% | + 4 worked examples | concise steps, `#### <number>` |
+
+The visible change: with **no few-shot examples in its prompt**, the student's held-out accuracy jumps
+**63% → 72%, matching the few-shot teacher** — the teacher's reasoning is now baked into the student's
+LoRA. Sample transcripts also get noticeably more concise (closer to the teacher's worked style) instead
+of the bare model's rambling. The whole run costs roughly **$1 of A100-40GB time**.
+
+Here is a held-out problem the bare student got **wrong** and the trained student got **right** — same
+bare prompt, greedy decode:
+
+> *Susan earns $5 every 10 minutes for an online task she does. If she works between 8 a.m. and 11 a.m. and
+> pauses in between for half an hour, how much money does she earn?*  (answer: $75)
+
+**Before OPD** — the bare student *lists* the half-hour pause, then forgets to subtract it, and confidently
+boxes the wrong total:
+
+```text
+### Given:
+- Susan earns $5 every 10 minutes.
+- She works between 8 a.m. and 11 a.m.
+- She pauses for half an hour in between.       ← noted, then ignored
+
+### Step 1: total time = 11 − 8 = 3 hours = 180 minutes
+### Step 2: 180 / 10 = 18 intervals
+### Step 3: 18 × $5 = $90
+
+Final Answer: 90
+```
+
+**After OPD** — it accounts for the pause and lands the right answer, in the teacher's concise style:
+
+```text
+From 8 a.m. to 11 a.m. is 3 hours. She pauses half an hour, so she works 3 − 0.5 = 2.5 hours = 150 minutes.
+In 10 minutes she earns $5, so 150 / 10 = 15 intervals.
+15 × $5 = $75.
+```
+
+This isn't a one-off: on the held-out set, far more problems flip wrong → right than the reverse (**13 vs 6**
+in this run — the net is the accuracy gain above). The bare model's typical failure is exactly the above —
+an ornate setup that drops a constraint or runs out of the token budget mid-derivation — and OPD makes it
+commit to the teacher's short, complete arithmetic.
+
+The same tightening happens **even on problems the bare model already gets right** — it just stops rambling.
+Same bare prompt, same answer (142), before and after:
+
+> *Ricardo grows tomatoes and eggplants in his garden. Each tomato plant yields 22 tomatoes while each plant
+> of eggplant yields 4 eggplants. He planted 5 tomato plants and 8 plants of eggplant. How many fruits can
+> Ricardo get from his plants?*  (answer: 142)
+
+**Before OPD** — opens with markdown headers and boilerplate; 256 tokens in, it is still *setting up*:
+
+```text
+Let's break down the problem step by step:
+
+### Given:
+- Each **tomato plant** yields **22 tomatoes**.
+- Each **eggplant plant** yields **4 eggplants**.
+- Ricardo planted:
+  - 5 **tomato plants**
+  - 8 **eggplant plants**
+
+---
+
+### Step 1:                       ← (still just restating the problem here)
+```
+
+**After OPD** — straight to the arithmetic, in the teacher's concise style:
+
+```text
+Ricardo's tomato plants: 5 plants × 22 tomatoes = 110 tomatoes
+Ricardo's eggplant plants: 8 plants × 4 eggplants = 32 eggplants
+Total fruits: 110 + 32 = 142
+
+Ricardo can get 142 fruits from his plants.
+```
+
+More real transcripts — including the other wrong → right flips — are in
+[`examples/on_policy_distillation/sample_outputs.md`](https://github.com/agentscope-ai/TuFT/blob/main/examples/on_policy_distillation/sample_outputs.md).
+
+OPD improves **fast** — most of the gain lands within a handful of steps (dense per-token signal). Reverse-KL
+is mode-seeking and can over-train if pushed far (accuracy drifts back down after a few dozen steps), so we
+keep the run short; `--num-steps 16` is a good default (see [Parameter Selection](#parameter-selection)).
+
+---
+
+## Parameter Selection
+
+- **`learning_rate`** — `1e-4` is a stable default (same as the RL example). Reverse-KL is touchier than
+  cross-entropy; if loss spikes or the student degenerates, halve it.
+- **`kl_coef` / `adv_clip`** — scale and clip the per-token advantage. Keep `kl_coef=1.0`; `adv_clip` (default
+  `10`) just guards against rare huge log-prob gaps.
+- **`group_size`** — student samples per prompt. More samples = a denser, lower-variance signal per step
+  (and more teacher scoring calls). `4` is a good balance; drop to `1–2` to go faster.
+- **`temperature`** — sample rollouts at `~1.0` so the student explores tokens for the teacher to correct;
+  evaluate greedily (`0.0`).
+- **`lora_rank`** — `16` is plenty for this behavior transfer; raise toward `32–64` only for harder
+  capability gaps.
+- **`num_steps`** — OPD improves fast; most of the gain lands in the first handful of steps. Reverse-KL can
+  over-train (accuracy drifts back down if you keep going), so keep it short — `16` is a good default, and
+  the script prints periodic `--eval-every` accuracies so you can see the peak.
+- **teacher** — the gain tracks the *per-token capability gap*, not raw model size (see [Hosting](#hosting)).
+
+---
+
+## Q&A
+
+### (1) Why `importance_sampling` and not a dedicated "distillation" loss?
+
+Because OPD *is* policy-gradient with a per-token KL "reward." `importance_sampling` already computes
+`−Σ exp(target_lp − sampling_lp) · advantage`; setting `advantage = teacher_lp − student_lp` makes that the
+on-policy distillation update. No new loss function is needed — and you get RL-style importance correction
+for free if the sampler and trainer log-probs drift.
+
+### (2) The teacher and student use different prompts — is the KL still valid?
+
+Yes. The student and teacher define distributions over the **same answer tokens**, each conditioned on its
+own context. The reverse-KL is between those two conditionals at each answer position; minimizing it makes
+the bare-prompted student behave like the few-shot-prompted teacher. That is precisely the goal of context
+distillation.
+
+### (3) The accuracy jumps but the student still doesn't emit the teacher's `####` line — why?
+
+On-policy distillation can only reshape the probability of tokens the student **actually samples**. The bare
+Qwen3 student reasons well but never explores the literal `####` marker, so the teacher never gets to score
+(and reinforce) it on the student's trajectory. What *does* transfer is the teacher's **reasoning quality and
+concision** on the tokens the student does produce — which is what lifts accuracy. This is a general property
+of on-policy methods: they sharpen and re-weight explored behavior, they don't graft in unexplored tokens.
+(To also transfer a surface format, seed it into the student prompt so it gets explored, or warm-start with a
+little SFT.)
+
+### (4) `compute_logprobs` returns `None` at some positions
+
+The first token has no preceding context, so its log-prob is `None`; the example treats any `None` as a
+zero advantage for that token. Because we always slice the **answer** region (`P + j` with `P ≥ 1`), this only
+matters defensively.
+
+### (5) Dataset download fails (huggingface.co unreachable)
+
+Set a mirror before importing `datasets`:
+```python
+import os
+os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+```
+
+### (6) OOM or slow on a small GPU
+
+Lower `--max-new-tokens`, `--group-size`, or `--batch-size` (in that order), and/or reduce
+`sampling_memory_fraction` / `sampling_max_model_len` in `config.yaml`. A 24GB L4 works with
+`--batch-size 4 --group-size 2`; keep the teacher and student on the same base model (the default) so only
+one model is resident on the GPU.

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -55,12 +55,13 @@ two strong same-family models mostly agree token-by-token.)
 ## 2. Run the training
 
 ```bash
-pip install tinker transformers datasets torch     # local deps, no GPU
+pip install tinker transformers datasets torch   # local deps, no GPU
 
+# --base-url: http://localhost:10610 locally, or the Modal URL from step 1
+# --api-key:  the key you put in config.yaml  (--model defaults to Qwen/Qwen3-1.7B)
 python examples/on_policy_distillation/train.py \
-    --base-url http://localhost:10610 \             # or the Modal URL from step 1
-    --api-key tml-...                               # the key you put in config.yaml
-# --model defaults to Qwen/Qwen3-1.7B (matches config.yaml)
+    --base-url http://localhost:10610 \
+    --api-key tml-...
 ```
 
 You'll see the **bare student** evaluated on held-out GSM8K, the **few-shot teacher** (the ceiling

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -1,0 +1,97 @@
+# On-Policy Distillation — internalize a few-shot teacher into the weights
+
+Train a small model with **on-policy distillation (OPD)**: the **student** samples answers to
+its *own* prompts, a **teacher** scores those exact tokens, and the student is nudged toward the
+teacher's per-token distribution. It is the recipe from Thinking Machines'
+[On-Policy Distillation](https://thinkingmachines.ai/blog/on-policy-distillation/) — dense
+per-token supervision (unlike RL's one scalar reward), and on the student's own trajectory
+(unlike off-policy SFT) — implemented on TuFT with the **same machinery as RL**
+(`importance_sampling` loss). This is a **client-side training script**: it drives the loop over
+HTTP against a running TuFT server. The same `train.py` works whether the server is local or on Modal.
+
+```
+dataset.py   GSM8K loader, teacher (few-shot) vs student (bare) prompts, the importance_sampling Datum builder
+train.py     connects to a TuFT server, evals before, runs OPD, evals after, saves the LoRA
+```
+
+**The task — math reasoning (GSM8K).** The teacher is the **same base model** but conditioned on a
+strong system prompt + four worked examples, so it reasons step by step and ends with `#### <number>`.
+The student sees only the bare question. OPD distills that few-shot behavior into the student's LoRA
+— so afterward the student reasons in the teacher's style *without the examples in its prompt*
+("context distillation"). Because teacher == student base model, the whole thing fits on **one GPU**.
+
+> **The general OPD recipe (any task).** `advantage[t] = teacher_logprob[t] − student_logprob[t]`
+> is the single-sample estimator of the negative per-token reverse-KL; feed it to the
+> `importance_sampling` loss. Swap in your own task by editing the prompts/data in `dataset.py`.
+
+## 1. Start a server
+
+A ready-to-use [`config.yaml`](./config.yaml) is included (Qwen3-1.7B on a single A100-40GB; a 24GB
+L4 also works with lighter settings — see the config comments). First put a real key in its
+`authorized_users` (replace `tml-CHANGE-ME`):
+
+```bash
+python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+```
+
+**Local:**
+```bash
+tuft launch --host 0.0.0.0 --port 10610 --config examples/on_policy_distillation/config.yaml
+```
+
+**On Modal** (server on a GPU, this loop on your laptop — see [`deploy/`](../../deploy/)). The
+`modal:` section in `config.yaml` supplies the infra (A100-40GB), so no extra flags are needed:
+```bash
+python deploy/modal/launch.py --config examples/on_policy_distillation/config.yaml
+# prints a URL like https://<workspace>--on-policy-distillation-tuftserver-serve.modal.run
+```
+
+**A different, larger teacher (e.g. Qwen3-8B)?** Run it on its own TuFT server and point `train.py` at it
+with `--teacher-model` / `--teacher-base-url` / `--teacher-api-key`. It isn't automatically better, though:
+OPD transfers *capability*, not just style, so it pays off only with a real per-token capability gap — a much
+weaker student or a harder task. (A modest size bump on an easy task, e.g. 8B → 1.7B on GSM8K, barely helps —
+two strong same-family models mostly agree token-by-token.)
+
+## 2. Run the training
+
+```bash
+pip install tinker transformers datasets torch     # local deps, no GPU
+
+python examples/on_policy_distillation/train.py \
+    --base-url http://localhost:10610 \             # or the Modal URL from step 1
+    --api-key tml-...                               # the key you put in config.yaml
+# --model defaults to Qwen/Qwen3-1.7B (matches config.yaml)
+```
+
+You'll see the **bare student** evaluated on held-out GSM8K, the **few-shot teacher** (the ceiling
+we distill toward), then — after ~16 steps — the **trained student** answering the same bare prompts.
+In our run held-out accuracy jumped **63% → 72%, matching the few-shot teacher**, with the student's
+reasoning now noticeably more concise — all from a bare prompt (no examples). OPD improves fast and
+reverse-KL can over-train, so the default keeps it short; `--eval-every` prints the trajectory.
+Tunables: `--num-steps`, `--batch-size`, `--group-size`, `--learning-rate`, `--lora-rank`,
+`--kl-coef`, `--num-train`, `--num-eval`. Edit `dataset.py` to swap in a different task.
+
+See [`sample_outputs.md`](./sample_outputs.md) for real before/after transcripts — including
+problems the bare model gets wrong that the distilled student then gets right.
+
+## 3. Get the weights
+
+The LoRA adapter + sampler weights are saved on the **server's** `checkpoint_dir`. On Modal that's a
+Volume — download the standard PEFT adapter (the `run_id` is printed at the end):
+
+```bash
+modal volume get tuft-checkpoints <run_id> ./weights/
+# -> ./weights/<run_id>/opd-final/adapter/{adapter_config.json, adapter_model.safetensors}
+```
+
+**Merge into full model weights** (optional; needs `torch`, `peft`, `transformers`):
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-1.7B", torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, "./weights/opd-final/adapter").merge_and_unload()
+merged.save_pretrained("./opd-merged")          # standard HF model dir, servable by vLLM
+```

--- a/examples/on_policy_distillation/config.yaml
+++ b/examples/on_policy_distillation/config.yaml
@@ -1,0 +1,54 @@
+# TuFT config for the on-policy distillation (OPD) example.
+#
+# Run a server with this, then train against it:
+#   Local:  tuft launch --host 0.0.0.0 --port 10610 --config examples/on_policy_distillation/config.yaml
+#   Modal:  python deploy/modal/launch.py --config examples/on_policy_distillation/config.yaml
+#           (infra comes from the `modal:` section below — no extra flags needed)
+#   Train:  python examples/on_policy_distillation/train.py --base-url <url> --api-key <your-tml-key>
+#
+# FIRST: replace the placeholder API key below with a strong one:
+#   python -c "import secrets; print('tml-' + secrets.token_urlsafe(24))"
+#
+# DEFAULT (this file): teacher == student == Qwen3-1.7B, so ONE model on ONE GPU with
+# colocate:true. The teacher's edge comes from a few-shot prompt (context distillation);
+# OPD bakes that behaviour into the student's LoRA. Cheap (~$1 on A100-40GB) and visible.
+#
+# GPU: A100-40GB has comfortable headroom for OPD (which both SAMPLES and TRAINS every step).
+# A 24GB L4 also works but is tight — if you hit OOM, set `modal.gpu: L4` AND lower the load:
+# `--batch-size 4 --group-size 2 --max-new-tokens 200`, and `sampling_memory_fraction: 0.35`.
+
+checkpoint_dir: ~/.cache/tuft/checkpoints   # (on Modal, launch.py pins this to a Volume automatically)
+model_owner: local-user
+
+supported_models:
+  - model_name: Qwen/Qwen3-1.7B
+    model_path: Qwen/Qwen3-1.7B            # HF id (downloaded on first launch) or a local path
+    max_model_len: 4096
+    sampling_max_model_len: 2048           # cap vLLM KV-cache (few-shot prompt + answer stay well under this)
+    tensor_parallel_size: 1
+    colocate: true                         # single GPU: training + vLLM share it
+    sampling_memory_fraction: 0.4          # vLLM's share — OPD samples AND scores every step
+    max_lora_rank: 16
+    max_loras: 4
+
+authorized_users:
+  tml-CHANGE-ME: local-user                # MUST start with "tml-" (Tinker SDK requirement)
+
+persistence:
+  mode: DISABLE
+
+telemetry:
+  enabled: false
+
+# Modal infra for deploy/modal/launch.py (TuFT ignores this; it's stripped before the server sees it):
+modal:
+  gpu: A100-40GB
+  name: on-policy-distillation
+  proxy_auth: false
+  min_containers: 0
+
+# ---------------------------------------------------------------------------------------
+# To distill from a DIFFERENT, larger teacher (e.g. Qwen3-8B): run it on its own TuFT server and point
+# train.py at it with --teacher-model / --teacher-base-url / --teacher-api-key. Note OPD transfers
+# capability (not just style), so a bigger teacher only helps with a real per-token capability gap — a much
+# weaker student or a harder task. A modest size bump on an easy task (e.g. 8B->1.7B on GSM8K) barely helps.

--- a/examples/on_policy_distillation/dataset.py
+++ b/examples/on_policy_distillation/dataset.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import random
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, cast
 
 import torch
 from tinker import types
@@ -106,12 +106,12 @@ def load_gsm8k(n_train: int, n_eval: int, seed: int = 0) -> tuple[List[Problem],
     rng.shuffle(train_rows)
     rng.shuffle(eval_rows)
 
-    train = [
-        Problem(r["question"].strip(), _gold_from_answer(r["answer"])) for r in train_rows[:n_train]
-    ]
-    evals = [
-        Problem(r["question"].strip(), _gold_from_answer(r["answer"])) for r in eval_rows[:n_eval]
-    ]
+    def to_problem(row: Any) -> Problem:
+        row = cast("dict[str, Any]", row)
+        return Problem(row["question"].strip(), _gold_from_answer(row["answer"]))
+
+    train = [to_problem(r) for r in train_rows[:n_train]]
+    evals = [to_problem(r) for r in eval_rows[:n_eval]]
     return train, evals
 
 

--- a/examples/on_policy_distillation/dataset.py
+++ b/examples/on_policy_distillation/dataset.py
@@ -1,0 +1,231 @@
+"""
+Data + prompt helpers for the on-policy distillation (OPD) example.
+
+Task: grade-school math word problems (GSM8K). The TEACHER is the base model guided by a
+strong system prompt + a few worked few-shot examples (so it reasons step by step and ends
+with ``#### <number>``). The STUDENT sees only a bare prompt (no examples). On-policy
+distillation trains the student's LoRA to match the teacher's per-token distribution on the
+student's OWN samples — internalising the few-shot behaviour into the weights, so the student
+reasons well WITHOUT the examples.
+
+Teacher and student are the SAME base model (the teacher's only edge is the few-shot prompt),
+so the whole thing fits on one GPU. This "context distillation" gives a strong, clean OPD
+signal; a *different, larger* teacher helps only in proportion to the per-token capability gap
+(see the user guide), not raw model size.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import torch
+from tinker import types
+from tinker.types.tensor_data import TensorData
+
+
+# --------------------------------------------------------------------------------------
+# Prompts: the ONLY difference between teacher and student is the few-shot "context".
+# --------------------------------------------------------------------------------------
+
+STUDENT_SYSTEM = "You are a helpful assistant. Solve the math problem."
+
+TEACHER_SYSTEM = (
+    "You are an expert math tutor. Solve each problem step by step with short, clear "
+    "reasoning, then give the final numeric answer on its own line in the exact format "
+    "'#### <number>'."
+)
+
+# A handful of worked GSM8K-style exemplars shown ONLY to the teacher. These create the
+# capability gap that on-policy distillation transfers into the student's weights.
+FEWSHOT: List[tuple[str, str]] = [
+    (
+        "Natalia sold clips to 48 of her friends in April, and then she sold half as "
+        "many clips in May. How many clips did she sell altogether in April and May?",
+        "In April she sold 48 clips.\n"
+        "In May she sold half as many: 48 / 2 = 24 clips.\n"
+        "Altogether: 48 + 24 = 72 clips.\n"
+        "#### 72",
+    ),
+    (
+        "Weng earns $12 an hour for babysitting. Yesterday, she just did 50 minutes of "
+        "babysitting. How much did she earn?",
+        "Per minute she earns 12 / 60 = $0.2.\nFor 50 minutes: 50 * 0.2 = $10.\n#### 10",
+    ),
+    (
+        "Betty is saving money for a new wallet which costs $100. Betty has only half of "
+        "the money she needs. Her parents decided to give her $15, and her grandparents "
+        "twice as much as her parents. How much more money does Betty need?",
+        "Betty has half of $100: 100 / 2 = $50.\n"
+        "Her grandparents give twice the parents' $15: 2 * 15 = $30.\n"
+        "Now she has 50 + 15 + 30 = $95.\n"
+        "She still needs 100 - 95 = $5.\n"
+        "#### 5",
+    ),
+    (
+        "James writes a 3-page letter to 2 different friends twice a week. How many pages "
+        "does he write a year?",
+        "Each time he writes 3 * 2 = 6 pages.\n"
+        "Twice a week: 6 * 2 = 12 pages per week.\n"
+        "In a year: 12 * 52 = 624 pages.\n"
+        "#### 624",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class Problem:
+    question: str
+    gold: str  # the gold final answer, e.g. "72"
+
+
+# --------------------------------------------------------------------------------------
+# Dataset
+# --------------------------------------------------------------------------------------
+
+_GOLD_RE = re.compile(r"####\s*(.+)")
+_NUM_RE = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+
+
+def _gold_from_answer(answer: str) -> str:
+    m = _GOLD_RE.search(answer)
+    raw = m.group(1) if m else answer
+    return raw.strip().replace(",", "").replace("$", "")
+
+
+def load_gsm8k(n_train: int, n_eval: int, seed: int = 0) -> tuple[List[Problem], List[Problem]]:
+    """Load small train/eval slices of GSM8K (downloaded via `datasets`)."""
+    from datasets import load_dataset
+
+    ds = load_dataset("openai/gsm8k", "main")
+    train_rows = list(ds["train"])
+    eval_rows = list(ds["test"])
+    rng = random.Random(seed)
+    rng.shuffle(train_rows)
+    rng.shuffle(eval_rows)
+
+    train = [
+        Problem(r["question"].strip(), _gold_from_answer(r["answer"])) for r in train_rows[:n_train]
+    ]
+    evals = [
+        Problem(r["question"].strip(), _gold_from_answer(r["answer"])) for r in eval_rows[:n_eval]
+    ]
+    return train, evals
+
+
+# --------------------------------------------------------------------------------------
+# Prompt rendering
+# --------------------------------------------------------------------------------------
+
+
+def _render_ids(tokenizer, messages: list[dict]) -> List[int]:
+    try:
+        text = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True, enable_thinking=False
+        )
+    except TypeError:  # older templates without enable_thinking
+        text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    return tokenizer.encode(text, add_special_tokens=False)
+
+
+def student_prompt_ids(tokenizer, question: str) -> List[int]:
+    """Bare prompt the STUDENT is trained on — no few-shot examples."""
+    messages = [
+        {"role": "system", "content": STUDENT_SYSTEM},
+        {"role": "user", "content": question},
+    ]
+    return _render_ids(tokenizer, messages)
+
+
+def teacher_prompt_ids(tokenizer, question: str) -> List[int]:
+    """Rich prompt the TEACHER is conditioned on — system instruction + few-shot examples."""
+    messages: list[dict] = [{"role": "system", "content": TEACHER_SYSTEM}]
+    for q, a in FEWSHOT:
+        messages.append({"role": "user", "content": q})
+        messages.append({"role": "assistant", "content": a})
+    messages.append({"role": "user", "content": question})
+    return _render_ids(tokenizer, messages)
+
+
+# --------------------------------------------------------------------------------------
+# Answer extraction + scoring (for the visible before/after accuracy)
+# --------------------------------------------------------------------------------------
+
+
+def extract_pred(text: str) -> Optional[str]:
+    """Pull the predicted number: prefer the '#### N' marker, else the last number."""
+    m = _GOLD_RE.search(text)
+    if m:
+        nums = _NUM_RE.findall(m.group(1))
+        if nums:
+            return nums[-1].replace(",", "")
+    nums = _NUM_RE.findall(text)
+    return nums[-1].replace(",", "") if nums else None
+
+
+def _as_float(s: str) -> Optional[float]:
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def is_correct(text: str, gold: str) -> bool:
+    pred = extract_pred(text)
+    if pred is None:
+        return False
+    pf, gf = _as_float(pred), _as_float(gold)
+    if pf is not None and gf is not None:
+        return abs(pf - gf) < 1e-4
+    return pred.strip() == gold.strip()
+
+
+# --------------------------------------------------------------------------------------
+# Datum builder — identical alignment to examples/countdown_rl, but with a PER-TOKEN
+# advantage (the on-policy distillation signal) instead of one scalar advantage.
+# --------------------------------------------------------------------------------------
+
+
+def build_distillation_datum(
+    *,
+    prompt: types.ModelInput,
+    answer_tokens: Sequence[int],
+    sampling_logprobs: Sequence[float],
+    advantages: Sequence[float],
+) -> types.Datum:
+    """Build an importance_sampling Datum for one student rollout.
+
+    The server computes the (differentiable) current-policy logprob of ``target_tokens``;
+    the importance_sampling loss is ``-(exp(target_logprobs - logprobs) * advantages).sum()``.
+    With ``advantages[t] = teacher_logprob[t] - student_logprob[t]`` this is the single-sample
+    REINFORCE estimator of the per-token reverse-KL gradient — i.e. on-policy distillation.
+    """
+    toks = list(answer_tokens)
+    # model_input excludes the final answer token (next-token prediction).
+    model_input = prompt.append(types.EncodedTextChunk(tokens=toks[:-1]))
+    ob_len = prompt.length - 1
+
+    target_tokens = [0] * ob_len + toks
+    padded_logprobs = [0.0] * ob_len + list(sampling_logprobs)
+    padded_advantages = [0.0] * ob_len + list(advantages)
+
+    if not (
+        model_input.length == len(target_tokens) == len(padded_logprobs) == len(padded_advantages)
+    ):
+        raise ValueError(
+            f"length mismatch: model_input={model_input.length} target={len(target_tokens)} "
+            f"logprobs={len(padded_logprobs)} adv={len(padded_advantages)}"
+        )
+
+    return types.Datum(
+        model_input=model_input,
+        loss_fn_inputs={
+            "target_tokens": TensorData.from_torch(torch.tensor(target_tokens, dtype=torch.long)),
+            "logprobs": TensorData.from_torch(torch.tensor(padded_logprobs, dtype=torch.float32)),
+            "advantages": TensorData.from_torch(
+                torch.tensor(padded_advantages, dtype=torch.float32)
+            ),
+        },
+    )

--- a/examples/on_policy_distillation/sample_outputs.md
+++ b/examples/on_policy_distillation/sample_outputs.md
@@ -1,0 +1,331 @@
+# Sample outputs — before vs. after OPD
+
+Real, greedy-decoded generations from this example: a **Qwen3-1.7B** student, distilled on-policy from a
+**few-shot Qwen3-1.7B teacher** (`train.py`, 16 steps, `lr=1e-4`, rank 16, single A100-40GB). Both columns
+use the **same bare prompt** (just the question) — the few-shot examples are baked into the student's LoRA,
+not shown at inference.
+
+On the held-out GSM8K slice (seed 0, 80 problems): **bare student 62.5% → after OPD 71.2%**, with
+**13 problems flipping wrong → right** and 6 going the other way (net +7). A representative selection is below.
+
+> These are captured from one real run. Sampling and training have run-to-run variance, so the exact
+> problems, wording, and numbers will differ if you re-run — the *pattern* (ornate-and-wrong → short-and-right)
+> is what reproduces.
+
+The bare model fails in two recurring ways. Both are fixed the same way: OPD makes the student commit to the
+teacher's short, complete arithmetic instead of an open-ended essay.
+
+---
+
+## A. Dropped or mishandled a constraint
+
+### Susan's earnings — ignores the half-hour pause  (answer: 75)
+
+> Susan earns $5 every 10 minutes for an online task she does. If she works between 8 a.m. and 11 a.m. and
+> pauses in between for half an hour, how much money does she earn for the online task?
+
+**Before (wrong → $90):** lists the pause in "Given", then never subtracts it.
+```text
+Let's break down the problem step by step.
+
+### Given:
+- Susan earns **$5 every 10 minutes**.
+- She works **between 8 a.m. and 11 a.m.**.
+- She **pauses for half an hour** in between.
+
+### Step 1: Determine the total time she works
+From 8 a.m. to 11 a.m. is:
+$$
+11 - 8 = 3 \text{ hours} = 180 \text{ minutes}
+$$
+
+### Step 2: Determine how many 10-minute intervals fit into 180 minutes
+$$
+\frac{180}{10} = 18 \text{ intervals}
+$$
+
+### Step 3: Calculate how much she earns
+$$
+18 \text{ intervals} \times \$5 = \$90
+$$
+
+### Final Answer:
+$$
+\boxed{90}
+$$
+
+Susan earns **$90** for the online task.
+```
+
+**After (correct → $75):**
+```text
+Susan works between 8 a.m. and 11 a.m., which is 3 hours. She pauses for half an hour in between, so she works for 3 - 0.5 = 2.5 hours.
+
+In 10 minutes, she earns $5. There are 10 minutes in 1 hour, so in 2.5 hours, she works 2.5 * 60 = 150 minutes.
+
+150 minutes / 10 minutes = 15 intervals.
+
+15 intervals * $5 = $75.
+
+Susan earns $75 for the online task.
+
+$$
+\boxed{75}
+$$
+```
+
+### Roger's coffee — buys only the expensive brand, but the bare model counts both  (answer: 44)
+
+> Roger goes to the store to buy some coffee. The normal brand of coffee he buys cost $5 per pound. He had
+> to buy a more expensive brand that cost 20% more since his favorite brand was sold out. He decides to buy
+> a week's worth of coffee and he uses 1 pound of coffee per day. He also decided to buy himself a donut for
+> $2. How much did everything cost?
+
+**Before (wrong → $79):** adds the normal-brand cost *and* the expensive-brand cost (he only buys the expensive one).
+```text
+Let's break this down step by step:
+
+### 1. **Cost of the normal brand of coffee:**
+- Price per pound = $5
+- He buys **1 pound per day** for **1 week** (7 days)
+- Total coffee cost = $5 × 7 = **$35**
+
+### 2. **Cost of the more expensive brand:**
+- It's **20% more expensive** than the normal brand
+- 20% of $5 = $1
+- So, the more expensive brand costs $5 + $1 = **$6 per pound**
+- He still buys **1 pound per day** for 7 days
+- Total cost for the more expensive brand = $6 × 7 = **$42**
+
+### 3. **Cost of the donut:**
+- He buys a donut for **$2**
+
+### 4. **Total cost:**
+- Coffee (normal + more expensive) = $35 + $42 = **$77**
+- Donut = **$2**
+- **Total cost = $77 + $2 = $79**
+
+### ✅ Final Answer: **$79
+```
+
+**After (correct → $44):**
+```text
+The normal coffee costs $5 per pound. The more expensive brand is 20% more expensive, so it costs $5 * 1.20 = $6 per pound.
+
+He uses 1 pound per day for a week, so he needs 7 pounds.
+
+The cost of the coffee is 7 pounds * $6 = $42.
+
+He also buys a donut for $2.
+
+Total cost = $42 + $2 = $44.
+
+The answer is $44.
+```
+
+### Tom's trip — counts only 3 days of the second week instead of 7  (answer: 3140)
+
+> Tom went on a two-week-long trip through Europe. In the first 4 days, he traveled 200 kilometers every day,
+> and over the next two days, he totaled only 30% of the distance traveled over the first four days. On the
+> next day, he wasn't traveling at all. During the second week, he made 300 kilometers every day. How many
+> kilometers in total did Tom make during his two-week-long trip?
+
+**Before (wrong):** uses "Days 8 to 10" (3 days) for the second week, then runs out of tokens.
+```text
+Let's break down Tom's trip into parts and calculate the total distance he traveled.
+
+### **First Week:**
+
+- **Days 1 to 4:**
+  He traveled **200 km/day** for 4 days.
+  Total = $ 4 \times 200 = 800 $ km
+
+- **Days 5 and 6:**
+  He traveled **30% of the distance** from the first 4 days.
+  30% of 800 km = $ 0.3 \times 800 = 240 $ km
+
+- **Day 7:**
+  He **was not traveling at all**, so distance = 0 km
+
+### **Second Week:**
+
+- **Days 8 to 10:**
+  He traveled **300 km/day** for 3 days.
+  Total = $ 3 \times 300 = 900 $ km
+
+### **Total Distance:**
+
+- First week: $ 800 + 240 + 0 = 1040 $ km
+- Second week: $ 900 $ km
+- **Total =
+```
+
+**After (correct → 3140):**
+```text
+First 4 days: 4 days * 200 km/day = 800 km
+Next 2 days: 30% of 800 km = 0.3 * 800 = 240 km
+Next day: 0 km
+Second week: 7 days * 300 km/day = 2100 km
+Total: 800 + 240 + 0 + 2100 = 3140 km
+
+Answer: 3140 kilometers.
+```
+
+---
+
+## B. Over-elaborated and ran out of the 256-token budget before answering
+
+### Adam's rock stand — goes symbolic with `x` and never plugs in $100  (answer: 16)
+
+> Adam has $100 and wants to spend it to open a rock stand. He can buy rocks for $5 each and sell them for
+> $7 each. If he invests all his money in the rock stand but only sells 60% of his inventory, how much money
+> does he lose?
+
+**Before (wrong — no final number):**
+```text
+Let's break down the problem step by step.
+
+### **Step 1: Total money Adam has**
+Adam has **$100**.
+
+### **Step 2: Cost of rocks**
+- Each rock costs **$5**.
+- He wants to buy rocks to open a rock stand.
+- He will sell **60%** of his inventory.
+
+So, he needs to buy enough rocks to sell 60% of his inventory.
+
+Let’s assume he buys **$x$** rocks.
+
+- Cost of rocks = $5x$
+- He sells 60% of the rocks = $0.6x$
+- Selling price per rock = $7
+- Total revenue from selling 60% = $7 \times 0.6x = 4.2x$
+
+### **Step 3: Set up the equation**
+
+He spends $5x$ to buy the rocks, and earns $4.2x$ by selling them.
+
+So, the net profit is:
+
+$$
+\text{Net profit} = 4.2x - 5x = -0.8x
+$$
+
+This means he **loses** $0.8x$.
+
+### **Step 4:
+```
+
+**After (correct → 16):**
+```text
+Adam buys 100 / 5 = 20 rocks. He sells 60% of them: 20 * 0.6 = 12 rocks. He earns 12 * 7 = 84 dollars. He loses 100 - 84 = 16 dollars.
+
+The answer is 16.
+```
+
+### Jamal's phone — correct setup, runs out one division short  (answer: 6)
+
+> Jamal's phone can hold 6 times more photographs than can Brittany's phone. The maximum number of
+> photographs that Brittany's phone can hold is 50 times more than the number of birds in Jamal's photograph
+> of the ducks at the zoo. If Jamal's phone can hold 1800 photographs, how many ducks can be seen in Jamal's
+> photograph of ducks at the zoo?
+
+**Before (wrong — cut off at the last step):**
+```text
+We are given the following information:
+
+1. **Jamal's phone can hold 6 times more photographs than Brittany's phone.**
+   Let $ J $ = number of photographs Jamal's phone can hold
+   Let $ B $ = number of photographs Brittany's phone can hold
+   So, $ J = 6B $
+
+2. **The maximum number of photographs that Brittany's phone can hold is 50 times more than the number of birds in Jamal's photograph of the ducks at the zoo.**
+   Let $ D $ = number of birds in Jamal's photograph of the ducks
+   So, $ B = 50D $
+
+3. **Jamal's phone can hold 1800 photographs.**
+   So, $ J = 1800 $
+
+### Step 1: Use $ J = 6B $ to find $ B $
+
+$$
+1800 = 6B \Rightarrow B = \frac{1800}{6} = 300
+$$
+
+### Step 2: Use $ B = 50D $ to find $ D $
+
+$$
+300 = 50D \Rightarrow D = \frac{300}{
+```
+
+**After (correct → 6):**
+```text
+Let's break it down step by step:
+
+1. Jamal's phone can hold 1800 photographs.
+2. Jamal's phone can hold 6 times more photographs than Brittany's phone.
+   So, Brittany's phone can hold $ \frac{1800}{6} = 300 $ photographs.
+3. Brittany's phone can hold 50 times more than the number of birds in Jamal's photograph of the ducks at the zoo.
+   So, the number of birds is $ \frac{300}{50} = 6 $.
+
+The number of ducks in Jamal's photograph is 6.
+
+$$
+\boxed{6}
+$$
+```
+
+### Freda's tomato sauce — runs out before counting the cans  (answer: 12)
+
+> When Freda cooks canned tomatoes into sauce, they lose half their volume. Each 16 ounce can of tomatoes
+> that she uses contains three tomatoes. Freda's last batch of tomato sauce made 32 ounces of sauce. How many
+> tomatoes did Freda use?
+
+**Before (wrong — cut off mid-derivation):**
+```text
+Let's break down the problem step by step.
+
+### **Given:**
+
+- **Each 16-ounce can of tomatoes contains 3 tomatoes.**
+- **When cooked, the volume of tomatoes loses half.**
+- **Freda's last batch of tomato sauce made 32 ounces of sauce.**
+
+### **Step 1: Understand the volume loss**
+
+When Freda cooks the tomatoes into sauce, **half their volume is lost**. So, the **final volume of sauce is half the volume of the tomatoes used**.
+
+Let’s denote the **original volume of tomatoes used** as $ V $.
+
+Then, the **final volume of sauce** is:
+$$
+\text{Final volume} = \frac{V}{2}
+$$
+
+We are told that the final volume of sauce is **32 ounces**. So:
+$$
+\frac{V}{2} = 32
+$$
+
+Multiply both sides by 2:
+$$
+V = 64 \text{ ounces}
+$$
+
+### **Step 2: Find how many cans of tomatoes were used**
+
+Each can contains **16 ounces of tomatoes**, and each can contains **3 tomatoes**.
+
+So, the number of cans used is:
+```
+
+**After (correct → 12):**
+```text
+Each can of tomatoes contains 3 tomatoes.
+Each can loses half its volume, so 16 ounces of tomatoes become 8 ounces of sauce.
+Freda made 32 ounces of sauce, so she used 32 / 8 = 4 cans.
+Each can has 3 tomatoes, so 4 cans * 3 tomatoes = 12 tomatoes.
+
+Answer: 12 tomatoes.
+```

--- a/examples/on_policy_distillation/train.py
+++ b/examples/on_policy_distillation/train.py
@@ -111,7 +111,8 @@ def main() -> None:
     ap.add_argument(
         "--teacher-model",
         default=None,
-        help="TEACHER model (default: same as --model). A different model needs a 2nd server.",
+        help="TEACHER model (default: same as --model). A different model needs its own server "
+        "and must share the student's tokenizer (e.g. any Qwen3 size).",
     )
     ap.add_argument(
         "--teacher-base-url",
@@ -167,6 +168,16 @@ def main() -> None:
         else tinker.ServiceClient(base_url=teacher_base_url, api_key=teacher_api_key)
     )
     tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    # We build the teacher's input from the STUDENT's token IDs (no re-tokenization), so a
+    # different teacher must share the student's tokenizer. Fail fast if it doesn't.
+    if teacher_model != args.model:
+        teacher_tok = AutoTokenizer.from_pretrained(teacher_model, trust_remote_code=True)
+        probe = "On-policy distillation: 1 + 2 = 3."
+        if teacher_tok.encode(probe) != tok.encode(probe):
+            raise SystemExit(
+                f"--teacher-model ({teacher_model}) must share the student's tokenizer "
+                f"({args.model}); e.g. any Qwen3 size. Otherwise the per-token IDs won't align."
+            )
 
     train_problems, eval_problems = load_gsm8k(args.num_train, args.num_eval, args.seed)
     print(f"[data] gsm8k train={len(train_problems)} eval={len(eval_problems)}", flush=True)
@@ -320,7 +331,7 @@ def main() -> None:
 
     # ---- AFTER: the trained student, on the SAME bare prompt ----
     sampler = training.save_weights_for_sampler(name=args.sampler_name).result(timeout=300)
-    run_id = sampler.path.split("tinker://")[1].split("/")[0]
+    run_id = sampler.path.removeprefix("tinker://").split("/")[0]
     trained = client.create_sampling_client(model_path=sampler.path)
     print("\n[after] trained student (bare prompt, few-shot now baked into the LoRA):", flush=True)
     after_acc, after_fmt = evaluate(

--- a/examples/on_policy_distillation/train.py
+++ b/examples/on_policy_distillation/train.py
@@ -1,0 +1,347 @@
+"""
+On-policy distillation (OPD) against a running TuFT server.
+
+This is a TRAINING-ONLY client script: it connects to a RUNNING TuFT server (it does NOT
+start one) and drives the loop over HTTP via the Tinker SDK. Stand the server up however
+you like, then point this at it:
+
+    # local:
+    tuft launch --host 0.0.0.0 --port 10610 --config examples/on_policy_distillation/config.yaml
+    python examples/on_policy_distillation/train.py --api-key tml-...
+
+    # or on Modal (server on a GPU, this loop on your laptop):
+    python deploy/modal/launch.py --config examples/on_policy_distillation/config.yaml
+    python examples/on_policy_distillation/train.py \
+        --base-url https://<workspace>--on-policy-distillation-tuftserver-serve.modal.run \
+        --api-key tml-...
+
+Local deps (no GPU):  pip install tinker transformers datasets torch
+
+How it works (the general OPD recipe — works for ANY task):
+  1. The STUDENT (a LoRA on the base model) samples answers to its OWN bare prompts.
+  2. The TEACHER scores those exact tokens with `compute_logprobs` (per-token logprobs).
+  3. advantage[t] = teacher_logprob[t] - student_logprob[t]   (negative per-token reverse-KL).
+  4. `forward_backward(..., loss_fn="importance_sampling")` + `optim_step` nudges the student
+     toward the teacher's distribution on the student's own trajectory.
+
+Here teacher == student base model, but the teacher is conditioned on a strong few-shot
+prompt while the student is not — so OPD distills that few-shot "context" into the weights
+(a.k.a. context distillation). A *different*, larger teacher can run on its own server (via
+--teacher-base-url), but OPD pays off in proportion to the per-token *capability* gap, not raw
+model size — see the user guide's Hosting section.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Callable, List
+
+import tinker
+from dataset import (
+    Problem,
+    build_distillation_datum,
+    is_correct,
+    load_gsm8k,
+    student_prompt_ids,
+    teacher_prompt_ids,
+)
+from tinker import types
+from transformers import AutoTokenizer
+
+
+def wait_healthy(base_url: str, timeout: float = 900.0) -> None:
+    """Block until GET /api/v1/healthz returns 200 (cold starts can take minutes)."""
+    url = base_url.rstrip("/") + "/api/v1/healthz"
+    deadline = time.time() + timeout
+    print(f"[wait] health-gating {url} ...", flush=True)
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=10) as r:
+                if r.status == 200:
+                    print("[wait] server healthy", flush=True)
+                    return
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(3)
+    raise SystemExit("server did not become healthy in time")
+
+
+def evaluate(
+    *,
+    sampler,
+    tok,
+    problems: List[Problem],
+    prompt_fn: Callable[[object, str], List[int]],
+    max_new_tokens: int,
+    show: int = 0,
+) -> tuple[float, float]:
+    """Greedy-decode `problems` from `sampler`; return (solve accuracy, `#### N` format rate)."""
+    sp = types.SamplingParams(max_tokens=max_new_tokens, temperature=0.0)
+    correct = 0
+    formatted = 0
+    for i, prob in enumerate(problems):
+        ids = prompt_fn(tok, prob.question)
+        out = sampler.sample(
+            prompt=types.ModelInput.from_ints(ids), num_samples=1, sampling_params=sp
+        ).result(timeout=240)
+        text = tok.decode(out.sequences[0].tokens, skip_special_tokens=True).strip()
+        ok = is_correct(text, prob.gold)
+        correct += int(ok)
+        formatted += int("####" in text)
+        if i < show:
+            print(f"   Q: {prob.question[:90]}", flush=True)
+            print(f"   A: {text[:240].replace(chr(10), ' / ')}", flush=True)
+            print(f"      -> gold={prob.gold}  {'CORRECT' if ok else 'wrong'}\n", flush=True)
+    n = max(1, len(problems))
+    return correct / n, formatted / n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="On-policy distillation against a TuFT server")
+    ap.add_argument("--base-url", default=os.getenv("TINKER_BASE_URL", "http://localhost:10610"))
+    ap.add_argument("--api-key", default=os.getenv("TINKER_API_KEY"))
+    ap.add_argument(
+        "--model", default="Qwen/Qwen3-1.7B", help="STUDENT base model (matches config.yaml)"
+    )
+    ap.add_argument(
+        "--teacher-model",
+        default=None,
+        help="TEACHER model (default: same as --model). A different model needs a 2nd server.",
+    )
+    ap.add_argument(
+        "--teacher-base-url",
+        default=None,
+        help="TEACHER server URL if --teacher-model is hosted separately (default: --base-url)",
+    )
+    ap.add_argument(
+        "--teacher-api-key", default=None, help="TEACHER server key (default: --api-key)"
+    )
+    ap.add_argument("--lora-rank", type=int, default=16)
+    ap.add_argument("--num-steps", type=int, default=16, help="OPD improves fast; keep it short")
+    ap.add_argument("--batch-size", type=int, default=8, help="prompts per step")
+    ap.add_argument("--group-size", type=int, default=4, help="student samples per prompt")
+    ap.add_argument("--learning-rate", type=float, default=1e-4)
+    ap.add_argument(
+        "--temperature", type=float, default=1.0, help="sampling temperature for rollouts"
+    )
+    ap.add_argument("--max-new-tokens", type=int, default=256)
+    ap.add_argument("--kl-coef", type=float, default=1.0, help="scales the per-token KL advantage")
+    ap.add_argument("--adv-clip", type=float, default=10.0, help="clip |advantage| for stability")
+    ap.add_argument("--num-train", type=int, default=256)
+    ap.add_argument("--num-eval", type=int, default=100)
+    ap.add_argument(
+        "--eval-every", type=int, default=0, help="eval the student every N steps (0 = off)"
+    )
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--sampler-name", default="opd-final")
+    ap.add_argument("--no-before", action="store_true", help="skip the before-eval")
+    ap.add_argument("--no-health-gate", action="store_true")
+    args = ap.parse_args()
+
+    if not args.api_key or not args.api_key.startswith("tml-"):
+        raise SystemExit("--api-key (or TINKER_API_KEY) must be set and start with 'tml-'")
+    teacher_model = args.teacher_model or args.model
+    teacher_base_url = args.teacher_base_url or args.base_url
+    teacher_api_key = args.teacher_api_key or args.api_key
+
+    random.seed(args.seed)
+    if not args.no_health_gate:
+        wait_healthy(args.base_url)
+        if teacher_base_url != args.base_url:
+            wait_healthy(teacher_base_url)
+
+    print(
+        f"[connect] student={args.model} @ {args.base_url}\n"
+        f"          teacher={teacher_model} @ {teacher_base_url}",
+        flush=True,
+    )
+    client = tinker.ServiceClient(base_url=args.base_url, api_key=args.api_key)
+    teacher_client = (
+        client
+        if teacher_base_url == args.base_url
+        else tinker.ServiceClient(base_url=teacher_base_url, api_key=teacher_api_key)
+    )
+    tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+
+    train_problems, eval_problems = load_gsm8k(args.num_train, args.num_eval, args.seed)
+    print(f"[data] gsm8k train={len(train_problems)} eval={len(eval_problems)}", flush=True)
+
+    teacher_sampler = teacher_client.create_sampling_client(base_model=teacher_model)
+
+    # ---- BEFORE: bare student vs. the few-shot teacher (the ceiling we distill toward) ----
+    base_acc = base_fmt = None
+    if not args.no_before:
+        base_sampler = client.create_sampling_client(base_model=args.model)
+        print("\n[before] bare student (base model, no few-shot):", flush=True)
+        base_acc, base_fmt = evaluate(
+            sampler=base_sampler,
+            tok=tok,
+            problems=eval_problems,
+            prompt_fn=student_prompt_ids,
+            max_new_tokens=args.max_new_tokens,
+            show=2,
+        )
+        print(
+            f"[before] bare-student accuracy = {base_acc:.1%}  (#### format = {base_fmt:.0%})",
+            flush=True,
+        )
+        teacher_acc, teacher_fmt = evaluate(
+            sampler=teacher_sampler,
+            tok=tok,
+            problems=eval_problems,
+            prompt_fn=teacher_prompt_ids,
+            max_new_tokens=args.max_new_tokens,
+        )
+        print(
+            f"[before] few-shot TEACHER accuracy (ceiling) = {teacher_acc:.1%}  "
+            f"(#### format = {teacher_fmt:.0%})",
+            flush=True,
+        )
+
+    # ---- TRAIN: on-policy distillation ----
+    training = client.create_lora_training_client(
+        base_model=args.model,
+        rank=args.lora_rank,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+    train_sp = types.SamplingParams(max_tokens=args.max_new_tokens, temperature=args.temperature)
+    print(
+        f"\n[train] {args.num_steps} steps | batch={args.batch_size} group={args.group_size} "
+        f"lr={args.learning_rate} rank={args.lora_rank}",
+        flush=True,
+    )
+
+    for step in range(args.num_steps):
+        # Sync the current student weights to a sampler so rollouts are ON-policy.
+        try:
+            student_path = (
+                training.save_weights_for_sampler(name=f"opd-step-{step:04d}").result().path
+            )
+            student_sampler = client.create_sampling_client(model_path=student_path)
+        except Exception as e:  # transient hiccup — skip this step and retry next
+            print(f"   [warn] step {step} setup failed, skipping: {e}", flush=True)
+            continue
+
+        batch = [
+            train_problems[random.randrange(len(train_problems))] for _ in range(args.batch_size)
+        ]
+        datums: List[types.Datum] = []
+        adv_sum, adv_n, solve_hits = 0.0, 0, 0
+
+        for prob in batch:
+            student_ids = student_prompt_ids(tok, prob.question)
+            student_prompt = types.ModelInput.from_ints(student_ids)
+            teacher_ids = teacher_prompt_ids(tok, prob.question)
+            p = len(teacher_ids)
+
+            try:
+                res = student_sampler.sample(
+                    prompt=student_prompt, num_samples=args.group_size, sampling_params=train_sp
+                ).result(timeout=300)
+            except Exception as e:  # transient server/network hiccup — skip this prompt
+                print(f"   [warn] sample failed, skipping prompt: {e}", flush=True)
+                continue
+
+            for seq in res.sequences:
+                answer = list(seq.tokens)
+                student_lp = list(seq.logprobs) if seq.logprobs is not None else None
+                if not answer or student_lp is None or len(student_lp) != len(answer):
+                    continue
+                if is_correct(tok.decode(answer, skip_special_tokens=True), prob.gold):
+                    solve_hits += 1
+
+                # Teacher scores the STUDENT's exact tokens (per-token logprobs).
+                teacher_input = types.ModelInput.from_ints(teacher_ids + answer)
+                try:
+                    tlp_full = teacher_sampler.compute_logprobs(teacher_input).result(timeout=300)
+                except Exception as e:  # transient hiccup — skip this rollout
+                    print(
+                        f"   [warn] teacher compute_logprobs failed, skipping rollout: {e}",
+                        flush=True,
+                    )
+                    continue
+
+                advantages: List[float] = []
+                for j in range(len(answer)):
+                    t_lp = tlp_full[p + j] if p + j < len(tlp_full) else None
+                    if t_lp is None:
+                        advantages.append(0.0)
+                        continue
+                    a = args.kl_coef * (float(t_lp) - student_lp[j])
+                    a = max(-args.adv_clip, min(args.adv_clip, a))
+                    advantages.append(a)
+                    adv_sum += a
+                    adv_n += 1
+
+                datums.append(
+                    build_distillation_datum(
+                        prompt=student_prompt,
+                        answer_tokens=answer,
+                        sampling_logprobs=student_lp,
+                        advantages=advantages,
+                    )
+                )
+
+        if datums:
+            fb = training.forward_backward(datums, loss_fn="importance_sampling").result(
+                timeout=300
+            )
+            training.optim_step(types.AdamParams(learning_rate=args.learning_rate)).result(
+                timeout=300
+            )
+            loss = fb.metrics.get("loss:sum", float("nan"))
+            mean_adv = adv_sum / max(1, adv_n)
+            n_samples = args.batch_size * args.group_size
+            print(
+                f"   step {step:3d}  rollouts={len(datums)}  loss={loss:.2f}  "
+                f"mean_adv={mean_adv:+.3f}  train_solve={solve_hits}/{n_samples}",
+                flush=True,
+            )
+
+        if args.eval_every and step > 0 and step % args.eval_every == 0:
+            acc, fmt = evaluate(
+                sampler=student_sampler,
+                tok=tok,
+                problems=eval_problems,
+                prompt_fn=student_prompt_ids,
+                max_new_tokens=args.max_new_tokens,
+            )
+            print(
+                f"   [eval@{step}] student accuracy = {acc:.1%}  (#### format = {fmt:.0%})",
+                flush=True,
+            )
+
+    # ---- AFTER: the trained student, on the SAME bare prompt ----
+    sampler = training.save_weights_for_sampler(name=args.sampler_name).result(timeout=300)
+    run_id = sampler.path.split("tinker://")[1].split("/")[0]
+    trained = client.create_sampling_client(model_path=sampler.path)
+    print("\n[after] trained student (bare prompt, few-shot now baked into the LoRA):", flush=True)
+    after_acc, after_fmt = evaluate(
+        sampler=trained,
+        tok=tok,
+        problems=eval_problems,
+        prompt_fn=student_prompt_ids,
+        max_new_tokens=args.max_new_tokens,
+        show=2,
+    )
+
+    print("\n==================  RESULT  ==================", flush=True)
+    print("                       accuracy   #### format", flush=True)
+    if base_acc is not None:
+        print(f"  bare student   :    {base_acc:6.1%}      {base_fmt:5.0%}", flush=True)
+    print(f"  after OPD      :    {after_acc:6.1%}      {after_fmt:5.0%}", flush=True)
+    print("=============================================", flush=True)
+    print(f"[save] sampler={sampler.path}\n[save] run_id={run_id}", flush=True)
+    print("On Modal, download the LoRA adapter with:", flush=True)
+    print(f"    modal volume get tuft-checkpoints {run_id} ./weights/", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a runnable **on-policy distillation (OPD)** example and user guide.

`examples/on_policy_distillation/` distills a few-shot teacher into a small student's LoRA on GSM8K: the student samples its own answers, the teacher scores those exact tokens via `compute_logprobs`, and the per-token advantage `teacher_logprob - student_logprob` is fed to the existing `importance_sampling` loss. No new server-side loss is needed — it's the same machinery as the RL example, with a per-token KL advantage instead of a reward.

- `train.py`, `dataset.py`, `config.yaml` — end-to-end client loop against a running TuFT server (local or Modal), single GPU.
- `sample_outputs.md` — real before/after transcripts, including wrong→right flips.
- `README.md` — how to run (local / Modal / weight download).

Docs: `user-guide/on-policy-distillation.md` (registered in the user-guide grid + toctree) and a row in the top-level README User Guide table.

## Result

Default is "context distillation": teacher and student are the same Qwen3-1.7B base model; the teacher's only edge is a few-shot prompt, which OPD bakes into the student's LoRA. On a single A100-40GB, ~16 steps, held-out GSM8K accuracy goes **~63% → ~72%** (matching the few-shot teacher) from a bare prompt, for roughly $1 of GPU time.

## Notes

- The guide documents **when OPD pays off**: the gain tracks the per-token *capability* gap, not raw model size. A genuinely larger same-family teacher (8B → 1.7B on GSM8K) did **not** beat this few-shot setup — two strong same-family models mostly agree token-by-token, so the signal is small and style-dominated.
- The `####` answer format does not transfer (on-policy only reshapes tokens the student actually samples); the reasoning quality/concision does, which is what lifts accuracy.

## Test plan

- Validated end-to-end on Modal (A100-40GB): bare 62–63% → after-OPD 72–74% on 100 held-out GSM8K problems; 13 wrong→right vs 6 right→wrong in a captured run.
- Verified the 24GB L4 reduced-load config (`--batch-size 4 --group-size 2`) runs the full pipeline (sample → teacher score → forward_backward → optim → save) without OOM.
- `ruff check` / `ruff format` clean on the example.
