### PR TITLE
ci: isolate Docker publish checkout on self-hosted runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          # Isolate each run from stale files in the persistent self-hosted
+          # runner workspace that can make checkout's pre-clean fail.
+          path: tuft-${{ github.run_id }}
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -55,9 +58,9 @@ jobs:
         id: push
         uses: docker/build-push-action@v4
         with:
-          context: .
+          context: tuft-${{ github.run_id }}
           push: true
-          file: docker/Dockerfile
+          file: tuft-${{ github.run_id }}/docker/Dockerfile
           shm-size: 128g
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- check out each Docker publish run into a run-specific directory
- point the Docker build context and Dockerfile path at that isolated checkout

## Root cause

The Docker publish job failed in `Checkout repository` before any Docker step ran. The self-hosted runner reuses its workspace, and stale files left by earlier runs can make `actions/checkout`'s pre-clean fail when using the workspace root.

Using a run-specific checkout directory prevents existing workspace contents from blocking checkout while preserving the requested release or manually supplied ref.

## Validation

- parsed `.github/workflows/docker.yml` with Ruby and PyYAML
- ran `git diff --check`
- confirmed the commit contains only `.github/workflows/docker.yml`

Related failure: https://github.com/agentscope-ai/TuFT/actions/runs/29311699412/job/87016648021
