### PR TITLE
Remove VERL dependency

### DIFF
--- a/.github/workflows/docker/docker-compose.yml
+++ b/.github/workflows/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       && source /root/.local/bin/env \
       && source /root/.tuft/venv/bin/activate \
       && uv pip install .[dev] \
-      && ray start --head --dashboard-host 0.0.0.0 --include-dashboard true --block"
+      && ray start --head --block"
     environment:
       - HF_ENDPOINT=https://hf-mirror.com
       - RAY_ADDRESS=auto

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -198,11 +198,7 @@ jobs:
       - name: Test upgrade command (from PyPI)
         run: |
           export PATH="${TUFT_HOME}/bin:$PATH"
-          # Prove an installed wrapper refreshes a stale pin before resolving.
-          printf '%s\n' 'verl==0.8.0' > "${TUFT_HOME}/scripts/verl-git-override.txt"
-          export TUFT_VERL_OVERRIDE_URL="file://${GITHUB_WORKSPACE}/scripts/verl-git-override.txt"
           tuft upgrade
-          cmp scripts/verl-git-override.txt "${TUFT_HOME}/scripts/verl-git-override.txt"
           "${TUFT_HOME}/venv/bin/python" -c \
             "from importlib.metadata import version; assert version('tuft') == '0.1.9'"
         env:

--- a/README.md
+++ b/README.md
@@ -252,17 +252,11 @@ We recommend using [uv](https://github.com/astral-sh/uv) for dependency manageme
 
 ### Install via PyPI
 
-Until Verl publishes a release containing its NumPy 2 fixes, PyPI installs
-must use TuFT's temporary override file:
-
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
-  -o /tmp/tuft-verl-git-override.txt
-uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
+uv pip install "tuft>=0.1.8"
 
 # Install optional dependencies as needed
-uv pip install --override /tmp/tuft-verl-git-override.txt \
-  "tuft[dev,backend,persistence,examples]>=0.1.8"
+uv pip install "tuft[dev,backend,persistence,examples]>=0.1.8"
 ```
 
 ### Run the server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ COPY ./scripts ./scripts
 RUN bash ./scripts/install.sh --local-source /workspace \
     && . $HOME/.local/bin/env \
     && . /root/.tuft/venv/bin/activate \
-    && uv pip install .[dev] --override scripts/verl-git-override.txt \
+    && uv pip install .[dev] \
     && python scripts/verify_runtime_versions.py
 
 ENTRYPOINT ["/bin/bash", "-c", "source ${VIRTUAL_ENV}/bin/activate && exec \"$@\"", "--"]

--- a/docs/sphinx_doc/source/getting-started/installation.md
+++ b/docs/sphinx_doc/source/getting-started/installation.md
@@ -69,17 +69,11 @@ We recommend using [uv](https://github.com/astral-sh/uv) for dependency manageme
 
 ## Install via PyPI
 
-Until Verl publishes a release containing its NumPy 2 fixes, PyPI installs
-must use TuFT's temporary override file:
-
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
-  -o /tmp/tuft-verl-git-override.txt
-uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
+uv pip install "tuft>=0.1.8"
 
 # Install optional dependencies as needed
-uv pip install --override /tmp/tuft-verl-git-override.txt \
-  "tuft[dev,backend,persistence]>=0.1.8"
+uv pip install "tuft[dev,backend,persistence]>=0.1.8"
 ```
 
 ## Use the Pre-built Docker Image

--- a/docs/sphinx_doc/source/user-guide/persistence.md
+++ b/docs/sphinx_doc/source/user-guide/persistence.md
@@ -38,9 +38,7 @@ This document is organized into two parts:
 ### Install optional dependency
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
-  -o /tmp/tuft-verl-git-override.txt
-uv pip install --override /tmp/tuft-verl-git-override.txt "tuft[persistence]>=0.1.8"
+uv pip install "tuft[persistence]>=0.1.8"
 ```
 
 ### Enable persistence

--- a/docs/sphinx_doc/source_zh/getting-started/installation.md
+++ b/docs/sphinx_doc/source_zh/getting-started/installation.md
@@ -69,17 +69,11 @@ tuft
 
 ## 通过 PyPI 安装
 
-在 Verl 发布包含 NumPy 2 修复的版本之前，通过 PyPI 安装时必须使用
-TuFT 提供的临时 override 文件：
-
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
-  -o /tmp/tuft-verl-git-override.txt
-uv pip install --override /tmp/tuft-verl-git-override.txt "tuft>=0.1.8"
+uv pip install "tuft>=0.1.8"
 
 # 根据需要安装可选依赖
-uv pip install --override /tmp/tuft-verl-git-override.txt \
-  "tuft[dev,backend,persistence]>=0.1.8"
+uv pip install "tuft[dev,backend,persistence]>=0.1.8"
 ```
 
 ## 使用预构建的 Docker 镜像

--- a/docs/sphinx_doc/source_zh/user-guide/persistence.md
+++ b/docs/sphinx_doc/source_zh/user-guide/persistence.md
@@ -38,9 +38,7 @@ TuFT 支持**可选的持久化**来保存服务器状态。启用后，TuFT 可
 ### 安装可选依赖
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt \
-  -o /tmp/tuft-verl-git-override.txt
-uv pip install --override /tmp/tuft-verl-git-override.txt "tuft[persistence]>=0.1.8"
+uv pip install "tuft[persistence]>=0.1.8"
 ```
 
 ### 启用持久化

--- a/examples/chat_sft/dataset.py
+++ b/examples/chat_sft/dataset.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple, cast
 
 import numpy as np
-from datasets import load_dataset
 from tinker import types
 
 
@@ -35,6 +34,8 @@ class ChatDataset:
 
 def load_chat_dataset(dataset_name: str, seed: int = 42) -> Tuple[ChatDataset, ChatDataset]:
     """Load train/test chat dataset."""
+    from datasets import load_dataset
+
     random.seed(seed)
 
     if dataset_name == "no_robots":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,18 +28,12 @@ dependencies = [
     "opentelemetry-instrumentation-logging>=0.41b0",
     "psutil>=5.9.0",
     "nvidia-ml-py>=13.0.0",
-    # Ray worker installs only main deps when packing; FSDP/verl + vLLM sampling need these
+    # Ray workers install only main dependencies when packing; training and sampling need these.
     # vLLM CUDA extensions are built against this exact PyTorch ABI.
     "torch==2.11.0",
     "peft>=0.18.0",
-    "tensordict>=0.5.0",
-    # Normal (registry-clean, publishable) metadata. The only released verl
-    # (0.8.0) hard-pins numpy<2.0.0, which conflicts with opencv (a vLLM dep,
-    # numpy>=2); verl #6551 (merged to main 2026-06-18) fixes this but is not yet
-    # released. We force the fixed commit via a uv override (see [tool.uv] below
-    # and scripts/verl-git-override.txt) rather than a direct URL here, so the
-    # published metadata stays clean and the <0.9 cap is honored.
-    "verl>=0.8.0,<0.9",
+    # Used by transformers device_map="auto" in the HF backend.
+    "accelerate>=1.0.0",
     # TuFT integrates with vLLM directly (src/tuft/backends/vllm_engine.py);
     # the in-process OpenAI API server shim and the prompt-logprobs worker
     # patch are validated against this exact release. Before changing the pin,
@@ -137,20 +131,6 @@ ruff = ["--fix"]
 
 [tool.nbqa.exclude]
 ruff = "^(\\.venv|tinker)/"
-
-[tool.uv]
-# Canonical rationale and removal procedure: scripts/verl-git-override.txt.
-# Force verl to the #6551 commit (numpy>=2 + vLLM/nccl runtime fixes). A normal
-# direct requirement can't satisfy verl>=0.8,<0.9 (the commit reports 0.9.0.dev0);
-# an override replaces the constraint. Covers project-mode installs (uv pip
-# install -e . / . / .[dev] / --local-source). install.sh and docker pass the
-# same pin via --override scripts/verl-git-override.txt for registry/git installs.
-# Once verl publishes a release containing #6551, remove this project override
-# and leave scripts/verl-git-override.txt present but comment-only so installed
-# wrappers refresh away the temporary pin.
-override-dependencies = [
-    "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0",
-]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = ["torch", "numpy"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,47 +200,14 @@ install_tuft() {
         PACKAGE_SPEC="$TUFT_PYPI_REQUIREMENT"
     fi
 
-    # Ensure the verl override file (pins verl to the #6551 commit) exists, then
-    # install with it so registry/git resolves satisfy verl>=0.8,<0.9.
-    setup_verl_override
-
     # PACKAGE_SPEC already includes the backend and persistence extras.
-    uv pip install --python "$TUFT_VENV/bin/python" --override "$VERL_OVERRIDE_FILE" "$PACKAGE_SPEC"
+    uv pip install --python "$TUFT_VENV/bin/python" "$PACKAGE_SPEC"
 
     print_success "TuFT installed successfully"
 }
 
-# Ensure the uv override file pinning verl to the #6551 commit exists at
-# $VERL_OVERRIDE_FILE (prefer the bundled file, else download, else write it
-# inline). See scripts/verl-git-override.txt for the rationale.
-setup_verl_override() {
-    mkdir -p "$(dirname "$VERL_OVERRIDE_FILE")"
-    if [ -n "$LOCAL_SOURCE_PATH" ] && [ -f "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" ]; then
-        cp "$LOCAL_SOURCE_PATH/scripts/verl-git-override.txt" "$VERL_OVERRIDE_FILE"
-        return
-    fi
-
-    local tmp_file="${VERL_OVERRIDE_FILE}.tmp"
-    if curl -fsSL "$VERL_OVERRIDE_URL" -o "$tmp_file" 2>/dev/null; then
-        mv "$tmp_file" "$VERL_OVERRIDE_FILE"
-    else
-        rm -f "$tmp_file"
-        # Offline / pre-merge fallback. Keep in sync with pyproject [tool.uv]
-        # override-dependencies and scripts/verl-git-override.txt.
-        if [ ! -f "$VERL_OVERRIDE_FILE" ]; then
-            printf '%s\n' "verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0" > "$VERL_OVERRIDE_FILE"
-        fi
-    fi
-}
-
 # URL for the flash-attn installation script
 FLASH_ATTN_SCRIPT_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/install_flash_attn.py"
-
-# uv override file that pins verl to the #6551 commit (numpy>=2 + runtime fixes).
-# scripts/verl-git-override.txt is the canonical decision record and removal
-# procedure. Pass it via --override on every supported install path.
-VERL_OVERRIDE_URL="https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt"
-VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
 
 # Install flash-attn from precompiled wheels (avoids lengthy compilation)
 # Also stores the script locally for later use by install-backend command
@@ -290,8 +257,6 @@ TUFT_HOME="${TUFT_HOME:-$HOME/.tuft}"
 TUFT_VENV="$TUFT_HOME/venv"
 TUFT_PYTHON="$TUFT_VENV/bin/python"
 TUFT_PYPI_REQUIREMENT="${TUFT_PYPI_REQUIREMENT:-tuft[backend,persistence]>=0.1.8}"
-VERL_OVERRIDE_URL="${TUFT_VERL_OVERRIDE_URL:-https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/verl-git-override.txt}"
-VERL_OVERRIDE_FILE="$TUFT_HOME/scripts/verl-git-override.txt"
 
 # Verify installation
 if [ ! -f "$TUFT_PYTHON" ]; then
@@ -300,27 +265,6 @@ if [ ! -f "$TUFT_PYTHON" ]; then
     echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/agentscope-ai/tuft/main/scripts/install.sh)"'
     exit 1
 fi
-
-# Atomically refresh the release-channel override before upgrades. Keep the
-# remote file at this stable URL after the workaround is removed (it can become
-# comment-only), so old wrappers stop applying the pin instead of retaining it.
-refresh_verl_override() {
-    mkdir -p "$(dirname "$VERL_OVERRIDE_FILE")"
-    local tmp_file="${VERL_OVERRIDE_FILE}.tmp"
-    if curl -fsSL "$VERL_OVERRIDE_URL" -o "$tmp_file" 2>/dev/null; then
-        mv "$tmp_file" "$VERL_OVERRIDE_FILE"
-        return
-    fi
-
-    rm -f "$tmp_file"
-    if [ -f "$VERL_OVERRIDE_FILE" ]; then
-        echo "Warning: could not refresh the Verl override; using the existing file."
-        return
-    fi
-
-    echo "Error: Verl override is unavailable. Re-run the TuFT installer."
-    return 1
-}
 
 # Handle commands
 case "${1:-}" in
@@ -359,30 +303,18 @@ case "${1:-}" in
         done
 
         echo "Upgrading TuFT..."
-        # verl is pinned to the #6551 commit via a uv override file placed at
-        # install time (scripts/verl-git-override.txt). Use --override (not a
-        # direct requirement): the commit reports 0.9.0.dev0, which a normal
-        # requirement can't satisfy against verl>=0.8,<0.9. Once verl publishes
-        # a release containing #6551, keep the remote file but make it
-        # comment-only so existing wrappers refresh away the temporary pin.
-        LOCAL_VERL_OVERRIDE="$UPGRADE_LOCAL_SOURCE/scripts/verl-git-override.txt"
-        if [ -n "$UPGRADE_LOCAL_SOURCE" ] && [ -f "$LOCAL_VERL_OVERRIDE" ]; then
-            cp "$LOCAL_VERL_OVERRIDE" "$VERL_OVERRIDE_FILE"
-        else
-            refresh_verl_override
-        fi
         if [ -n "$UPGRADE_LOCAL_SOURCE" ]; then
             echo "Upgrading from local source: $UPGRADE_LOCAL_SOURCE"
-            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "${UPGRADE_LOCAL_SOURCE}[backend,persistence]"
         elif [ "$UPGRADE_FROM_SOURCE" = true ]; then
             # Repo is overridable (default: upstream main) so CI / advanced users
             # can exercise the real VCS clone+build+resolve path against a
             # specific checkout, e.g. TUFT_GIT_URL="file://$GITHUB_WORKSPACE@$GITHUB_SHA".
             TUFT_GIT_URL="${TUFT_GIT_URL:-https://github.com/agentscope-ai/tuft.git}"
             echo "Upgrading from Git: git+${TUFT_GIT_URL}"
-            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "git+${TUFT_GIT_URL}#egg=tuft[backend,persistence]"
         else
-            uv pip install --python "$TUFT_PYTHON" --upgrade --override "$VERL_OVERRIDE_FILE" "$TUFT_PYPI_REQUIREMENT"
+            uv pip install --python "$TUFT_PYTHON" --upgrade "$TUFT_PYPI_REQUIREMENT"
         fi
 
         # Also update flash-attn
@@ -439,7 +371,6 @@ case "${1:-}" in
         echo "  TUFT_CHECKPOINT_DIR  Default checkpoint directory"
         echo "  TUFT_LOG_LEVEL       Default log level"
         echo "  TUFT_PYPI_REQUIREMENT Override the PyPI package requirement"
-        echo "  TUFT_VERL_OVERRIDE_URL Override the release-channel Verl override URL"
         echo ""
         echo "Examples:"
         echo "  tuft launch --config tuft_config.yaml"

--- a/scripts/verl-git-override.txt
+++ b/scripts/verl-git-override.txt
@@ -1,21 +1,5 @@
-# Temporary Verl override -- dependency decision record
+# Deprecated compatibility path.
 #
-# Decision: keep TuFT's published metadata as the normal, release-based
-# `verl>=0.8,<0.9` requirement, but have supported uv install paths replace it
-# with the pinned commit below via `--override`. The equivalent project-mode
-# override lives in pyproject.toml `[tool.uv].override-dependencies`.
-#
-# Rationale:
-# - Verl 0.8.0 pins NumPy <2, conflicting with TuFT's vLLM/OpenCV stack.
-# - verl-project/verl#6551 fixes the NumPy 2, vLLM, and NCCL runtime paths, but
-#   has not been released; its merge commit reports version 0.9.0.dev0.
-# - Adding that commit as a normal dependency would contradict TuFT's `<0.9`
-#   API cap and make the wheel metadata unsuitable for PyPI. A uv override
-#   substitutes the dependency only in the controlled installer/source/Docker
-#   flows while leaving the public compatibility contract explicit.
-#
-# Removal: after Verl publishes a compatible release, update the normal Verl
-# requirement and remove the pyproject override. Keep this file at this stable
-# path with comments only: previously installed `tuft upgrade` wrappers refresh
-# it before resolving, which removes the temporary pin for existing installs.
-verl @ git+https://github.com/verl-project/verl.git@14574ecf52e310055e4d6e9f116bcb14d343d7e0
+# TuFT no longer depends on VERL. This comment-only file remains for one release
+# so wrappers installed by older TuFT versions can refresh the former override
+# path without receiving a 404. New installs and upgrades do not read this file.

--- a/src/tuft/backends/fsdp_engine.py
+++ b/src/tuft/backends/fsdp_engine.py
@@ -1,0 +1,266 @@
+"""Torch-native forward/backward utilities for the FSDP training backend.
+
+This module intentionally owns only the small model-execution surface TuFT needs:
+model construction, contiguous micro-batching, next-token log-prob extraction, and
+loss/backward execution. FSDP wrapping, adapter management, optimizers, checkpoints,
+and distributed orchestration remain in :mod:`fsdp_training_backend`.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from tinker import types
+from torch.nn.utils.rnn import pad_sequence
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from tuft.loss_fn import get_loss_fn
+
+
+_RLHF_LOSS_FNS = {"ppo", "grpo", "cispo", "importance_sampling", "dro"}
+
+
+@dataclass
+class FSDPModelConfig:
+    """Minimal serializable model configuration used by FSDP workers."""
+
+    path: str
+    max_model_len: int
+    attn_implementation: str | None = None
+    override_config: dict[str, Any] = field(default_factory=dict)
+    trust_remote_code: bool = True
+
+
+@dataclass
+class MicroBatch:
+    """Padded model inputs plus the true per-sample sequence lengths."""
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    position_ids: torch.Tensor
+    labels: torch.Tensor
+    lengths: list[int]
+
+
+def build_base_model(config: FSDPModelConfig) -> Any:
+    """Load a single CPU copy of the base model and enable checkpointed training."""
+
+    override = dict(config.override_config)
+    attn_implementation = override.pop("attn_implementation", config.attn_implementation)
+    hf_config = AutoConfig.from_pretrained(
+        config.path,
+        trust_remote_code=config.trust_remote_code,
+    )
+    for key, value in override.items():
+        setattr(hf_config, key, value)
+
+    model_kwargs: dict[str, Any] = {
+        "config": hf_config,
+        "dtype": torch.bfloat16,
+        "low_cpu_mem_usage": True,
+        "trust_remote_code": config.trust_remote_code,
+    }
+    if attn_implementation is not None:
+        model_kwargs["attn_implementation"] = attn_implementation
+
+    model = AutoModelForCausalLM.from_pretrained(config.path, **model_kwargs)
+    model.enable_input_require_grads()
+    model.gradient_checkpointing_enable({"use_reentrant": False})
+    return model
+
+
+def _prepare_micro_batch(data: list[types.Datum], device: torch.device | str) -> MicroBatch:
+    """Pad model inputs and reproduce the prior flat rolled-label convention."""
+
+    if not data:
+        raise ValueError("A micro-batch must contain at least one datum")
+
+    sequences = [
+        torch.tensor(datum.model_input.to_ints(), dtype=torch.long, device=device) for datum in data
+    ]
+    lengths = [int(sequence.numel()) for sequence in sequences]
+    if any(length == 0 for length in lengths):
+        raise ValueError("FSDP forward does not support empty token sequences")
+
+    input_ids = pad_sequence(sequences, batch_first=True, padding_value=0)
+    max_len = input_ids.size(1)
+    token_positions = torch.arange(max_len, dtype=torch.long, device=device)
+    length_tensor = torch.tensor(lengths, dtype=torch.long, device=device)
+    attention_mask = (token_positions.unsqueeze(0) < length_tensor.unsqueeze(1)).long()
+    position_ids = token_positions.unsqueeze(0).expand(len(data), -1)
+
+    # The former engine rolled the flat concatenation, so the final label of each
+    # sample points at the first token of the next sample. Those positions are
+    # weight-masked by callers, but preserving the convention makes parity exact.
+    flat_labels = torch.roll(torch.cat(sequences), shifts=-1, dims=0)
+    labels = []
+    offset = 0
+    for length in lengths:
+        labels.append(flat_labels[offset : offset + length])
+        offset += length
+    labels_padded = pad_sequence(labels, batch_first=True, padding_value=0)
+
+    return MicroBatch(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        labels=labels_padded,
+        lengths=lengths,
+    )
+
+
+def _compute_target_logprobs(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    """Gather label log-probabilities without materializing a full fp32 log-softmax."""
+
+    if logits.dtype in (torch.float32, torch.float64):
+        label_logits = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
+        logsumexp = torch.stack([torch.logsumexp(row, dim=-1) for row in logits])
+        return label_logits - logsumexp
+
+    rows = []
+    for row_logits, row_labels in zip(logits, labels, strict=True):
+        row_logprobs = torch.nn.functional.log_softmax(row_logits, dim=-1)
+        rows.append(row_logprobs.gather(dim=-1, index=row_labels.unsqueeze(-1)).squeeze(-1))
+    return torch.stack(rows)
+
+
+def _datum_field(
+    datum: types.Datum,
+    key: str,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> torch.Tensor | None:
+    value = (datum.loss_fn_inputs or {}).get(key)
+    if value is None:
+        return None
+    return value.to_torch().to(device=device, dtype=dtype).reshape(-1)
+
+
+def _copy_row(destination: torch.Tensor, row: int, value: torch.Tensor) -> None:
+    width = min(destination.size(1), value.numel())
+    if width:
+        destination[row, :width] = value[:width]
+
+
+def _prepare_loss_fn_inputs(
+    data: list[types.Datum],
+    target_logprobs: torch.Tensor,
+    loss_fn_name: str,
+) -> dict[str, torch.Tensor]:
+    """Build padded TuFT loss inputs directly from Datum objects."""
+
+    batch_size, max_len = target_logprobs.shape
+    device = target_logprobs.device
+    if loss_fn_name.lower() in _RLHF_LOSS_FNS:
+        sampling_logprobs = target_logprobs.clone()
+        advantages = torch.zeros((batch_size, max_len), dtype=torch.float32, device=device)
+        for row, datum in enumerate(data):
+            old_logprobs = _datum_field(
+                datum,
+                "logprobs",
+                device=device,
+                dtype=torch.float32,
+            )
+            if old_logprobs is not None:
+                _copy_row(sampling_logprobs, row, old_logprobs)
+            advantage = _datum_field(
+                datum,
+                "advantages",
+                device=device,
+                dtype=torch.float32,
+            )
+            if advantage is not None:
+                _copy_row(advantages, row, advantage)
+        return {
+            "target_logprobs": target_logprobs,
+            "logprobs": sampling_logprobs,
+            "advantages": advantages,
+        }
+
+    weights = torch.zeros((batch_size, max_len), dtype=torch.float32, device=device)
+    for row, datum in enumerate(data):
+        value = _datum_field(datum, "weights", device=device, dtype=torch.float32)
+        if value is None:
+            value = torch.ones(len(datum.model_input.to_ints()), dtype=torch.float32, device=device)
+        _copy_row(weights, row, value)
+    return {"target_logprobs": target_logprobs, "weights": weights}
+
+
+def _merge_micro_metrics(metric_list: list[dict[str, Any]]) -> dict[str, float]:
+    """Combine numeric micro-batch metrics using their declared reduction."""
+
+    grouped: dict[str, list[float]] = {}
+    for metrics in metric_list:
+        for key, value in metrics.items():
+            if isinstance(value, (int, float)):
+                grouped.setdefault(key, []).append(float(value))
+
+    merged: dict[str, float] = {}
+    for key, values in grouped.items():
+        if key.endswith(":mean"):
+            merged[key] = sum(values) / len(values)
+        else:
+            merged[key] = sum(values)
+    return merged
+
+
+def forward_backward(
+    module: Any,
+    data: list[types.Datum],
+    loss_fn_name: str,
+    loss_fn_config: dict[str, float] | None,
+    micro_batch_size: int,
+    *,
+    forward_only: bool = False,
+) -> dict[str, Any]:
+    """Run contiguous micro-batches while preserving summed gradient accumulation."""
+
+    if not data:
+        return {"model_output": {"log_probs": []}, "metrics": {}}
+    if micro_batch_size <= 0:
+        raise ValueError(f"micro_batch_size must be positive, got {micro_batch_size}")
+
+    device = next(module.parameters()).device
+    loss_callable = get_loss_fn(loss_fn_name)
+    config = loss_fn_config or {}
+    per_sample_logprobs: list[torch.Tensor] = []
+    metric_list: list[dict[str, Any]] = []
+
+    grad_context = torch.no_grad() if forward_only else nullcontext()
+    with grad_context:
+        for start in range(0, len(data), micro_batch_size):
+            micro_data = data[start : start + micro_batch_size]
+            batch = _prepare_micro_batch(micro_data, device)
+            autocast = torch.autocast(
+                device_type="cuda",
+                dtype=torch.bfloat16,
+                enabled=device.type == "cuda",
+            )
+            with autocast:
+                outputs = module(
+                    input_ids=batch.input_ids,
+                    attention_mask=batch.attention_mask,
+                    position_ids=batch.position_ids,
+                    use_cache=False,
+                    return_dict=True,
+                )
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs["logits"]
+                target_logprobs = _compute_target_logprobs(logits, batch.labels)
+
+            loss_inputs = _prepare_loss_fn_inputs(micro_data, target_logprobs, loss_fn_name)
+            loss, metrics = loss_callable(loss_inputs, config)
+            if not forward_only:
+                loss.backward()
+            metric_list.append(metrics)
+            per_sample_logprobs.extend(
+                target_logprobs[row, :length].detach() for row, length in enumerate(batch.lengths)
+            )
+
+    return {
+        "model_output": {"log_probs": per_sample_logprobs},
+        "metrics": _merge_micro_metrics(metric_list),
+    }

--- a/src/tuft/backends/fsdp_engine.py
+++ b/src/tuft/backends/fsdp_engine.py
@@ -36,13 +36,20 @@ class FSDPModelConfig:
 
 @dataclass
 class MicroBatch:
-    """Padded model inputs plus the true per-sample sequence lengths."""
+    """Padded model inputs/labels plus the true per-sample sequence lengths."""
 
     input_ids: torch.Tensor
     attention_mask: torch.Tensor
     position_ids: torch.Tensor
     labels: torch.Tensor
     lengths: list[int]
+
+
+def _explicit_target_tokens(datum: types.Datum, device: torch.device | str) -> torch.Tensor | None:
+    value = (datum.loss_fn_inputs or {}).get("target_tokens")
+    if value is None:
+        return None
+    return value.to_torch().to(device=device, dtype=torch.long).reshape(-1)
 
 
 def build_base_model(config: FSDPModelConfig) -> Any:
@@ -73,7 +80,7 @@ def build_base_model(config: FSDPModelConfig) -> Any:
 
 
 def _prepare_micro_batch(data: list[types.Datum], device: torch.device | str) -> MicroBatch:
-    """Pad model inputs and reproduce the prior flat rolled-label convention."""
+    """Pad model inputs and labels, honoring explicit Tinker target tokens."""
 
     if not data:
         raise ValueError("A micro-batch must contain at least one datum")
@@ -92,14 +99,24 @@ def _prepare_micro_batch(data: list[types.Datum], device: torch.device | str) ->
     attention_mask = (token_positions.unsqueeze(0) < length_tensor.unsqueeze(1)).long()
     position_ids = token_positions.unsqueeze(0).expand(len(data), -1)
 
-    # The former engine rolled the flat concatenation, so the final label of each
-    # sample points at the first token of the next sample. Those positions are
-    # weight-masked by callers, but preserving the convention makes parity exact.
+    # Standard TuFT/Tinker training data carries already-shifted target_tokens
+    # in loss_fn_inputs. Use them when present so the final supervised token of
+    # each sample is preserved; fall back to the prior flat-roll convention only
+    # for legacy/RLHF-style rows that omit explicit targets.
     flat_labels = torch.roll(torch.cat(sequences), shifts=-1, dims=0)
     labels = []
     offset = 0
-    for length in lengths:
-        labels.append(flat_labels[offset : offset + length])
+    for datum, length in zip(data, lengths, strict=True):
+        explicit_targets = _explicit_target_tokens(datum, device)
+        if explicit_targets is not None:
+            if int(explicit_targets.numel()) != length:
+                raise ValueError(
+                    "target_tokens length must match model_input length: "
+                    f"got {int(explicit_targets.numel())} vs {length}"
+                )
+            labels.append(explicit_targets)
+        else:
+            labels.append(flat_labels[offset : offset + length])
         offset += length
     labels_padded = pad_sequence(labels, batch_first=True, padding_value=0)
 

--- a/src/tuft/backends/fsdp_training_backend.py
+++ b/src/tuft/backends/fsdp_training_backend.py
@@ -1,9 +1,4 @@
-"""
-FSDP training backend: multi-node/multi-GPU training via FSDP and multi-adapter LoRA.
-
-Peer to HFTrainingBackend; selected by ModelConfig.training_backend = "fsdp".
-Implements BaseTrainingBackend; uses MultiAdapterVerlWorker and adapts data/loss for the engine.
-"""
+"""Multi-node/multi-GPU training via FSDP2 and multi-adapter LoRA."""
 
 from __future__ import annotations
 
@@ -13,15 +8,13 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 from packaging import version
 from peft import LoraConfig, TaskType, get_peft_model
-from tensordict import TensorDict
 from tinker import types
 from torch.distributed.tensor import DTensor
-from verl.utils import tensordict_utils as tu
 
 
 # FSDP v2 imports (requires PyTorch >= 2.4)
@@ -39,18 +32,14 @@ else:
         f"FSDP v2 requires PyTorch >= 2.4, but got {torch.__version__}. "
         "Please upgrade PyTorch or use training_backend='hf' instead."
     )
-from transformers import AutoModelForCausalLM
-from verl.utils.dataset.dataset_utils import DatasetPadMode
-from verl.workers.config.engine import TrainingWorkerConfig
-from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
-
 from tuft.backends.base_backend import BaseTrainingBackend
+from tuft.backends.fsdp_engine import (
+    FSDPModelConfig,
+    build_base_model,
+    forward_backward as fsdp_forward_backward,
+)
 from tuft.checkpoints import CheckpointRecord
 from tuft.config import ModelConfig
-from tuft.loss_fn import get_loss_fn
-
-
-logger = logging.getLogger(__name__)
 
 
 def _shard_list(xs: list[Any], n_shards: int) -> list[list[Any]]:
@@ -92,297 +81,26 @@ def _merge_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
     return merged
 
 
-def _chunk_tensordict_allow_2d_nested(td: TensorDict, chunks: int) -> list | tuple:
-    """Chunk TensorDict like engine's chunk_tensordict; 2D nested use unbind."""
-    assert isinstance(td, TensorDict) and len(td) % chunks == 0, (
-        f"expecting td with length divisible by chunks, but got {len(td)} and {chunks}"
-    )
-    chunk_size = len(td) // chunks
-    # 2D nested (e.g. input_ids) do not support chunk/slice; use unbind
-    keys = {
-        key
-        for key, val in td.items()
-        if isinstance(val, torch.Tensor) and getattr(val, "is_nested", False) and val.dim() >= 2
-    }
-    new_td = TensorDict(
-        {k: v for k, v in td.items() if k not in keys},
-        batch_size=td.batch_size,
-        device=td.device,
-    )
-    tds = new_td.chunk(chunks=chunks)
-    for key in keys:
-        tensors = td[key].unbind(dim=0)
-        for i, sub_td in enumerate(tds):
-            sub_td[key] = torch.nested.as_nested_tensor(
-                tensors[i * chunk_size : (i + 1) * chunk_size], layout=torch.jagged
-            )
-    return tds
-
-
-# Monkey-patch so prepare_micro_batches uses 2D-nested-safe chunk (avoids NestedTensor slice)
-tu.chunk_tensordict = _chunk_tensordict_allow_2d_nested
-
 # Default port for torch.distributed init (multi-GPU). ModelConfig.fsdp_master_port should match.
 DEFAULT_MASTER_PORT = 29500
-
-
-# =============================================================================
-# Data and loss adaptation: Datum -> TensorDict, tuft loss -> engine loss_function
-# =============================================================================
-
-
-def _datum_list_to_tensordict(
-    data: list[types.Datum],
-    adapter_id: str,
-    device: str = "cuda",
-    micro_batch_size: Optional[int] = None,
-) -> "TensorDict":
-    """Convert list[types.Datum] to TensorDict (input_ids, position_ids, weights, etc.).
-
-    If `micro_batch_size` is given and divides len(data), verl's
-    `forward_backward_batch` will internally split into
-    `len(data) // micro_batch_size` micro-batches and accumulate gradients
-    across them (no zero_grad inside). This keeps the number of NCCL
-    collectives per RPC at 1 across all dp ranks (one
-    `all_reduce(batch_num_tokens)` + verl's `same_micro_num_in_dp` sync),
-    which is required to avoid dp-imbalance hangs in multi-rank FSDP.
-    """
-    from torch.nn.utils.rnn import pad_sequence
-
-    input_ids_list = [torch.tensor(datum.model_input.to_ints(), dtype=torch.long) for datum in data]
-    global_token_num = [x.size(0) for x in input_ids_list]
-    # NO_PADDING path expects 2D nested (batch, seq_len) for to_padded_tensor
-    # output_size=(batch_size, max_seq_len). Use `layout=torch.jagged` so
-    # downstream verl code can call `.offsets()` (required by
-    # `rearrange_micro_batches` under `use_dynamic_bsz=True`).
-    input_ids_nested = torch.nested.nested_tensor(
-        [t.to(device) for t in input_ids_list],
-        dtype=torch.long,
-        device=device,
-        layout=torch.jagged,
-    )
-    # position_ids must be 2D nested for prepare_model_inputs to_padded_tensor
-    position_ids_list = [
-        torch.arange(seq_len, dtype=torch.long, device=device)
-        for seq_len in (x.size(0) for x in input_ids_list)
-    ]
-    position_ids_nested = torch.nested.nested_tensor(
-        position_ids_list,
-        dtype=torch.long,
-        device=device,
-        layout=torch.jagged,
-    )
-
-    # target_tokens, weights for loss from loss_fn_inputs
-    target_tokens_list = []
-    weights_list = []
-    # RLHF-specific fields (logprobs, advantages)
-    logprobs_list = []
-    advantages_list = []
-    has_rlhf_fields = False
-
-    for datum in data:
-        inp = datum.loss_fn_inputs or {}
-        toks = inp.get("target_tokens")
-        target_tokens_list.append(
-            toks.to_torch() if toks is not None else torch.zeros(1, dtype=torch.long)
-        )
-        w = inp.get("weights")
-        default_weights = torch.ones(len(datum.model_input.to_ints()), dtype=torch.float32)
-        weights_list.append(w.to_torch() if w is not None else default_weights)
-
-        # Extract RLHF fields if present
-        logprobs = inp.get("logprobs")
-        if logprobs is not None:
-            has_rlhf_fields = True
-            logprobs_list.append(logprobs.to_torch())
-        else:
-            logprobs_list.append(torch.zeros(1, dtype=torch.float32))
-
-        advantages = inp.get("advantages")
-        if advantages is not None:
-            advantages_list.append(advantages.to_torch())
-        else:
-            advantages_list.append(torch.zeros(1, dtype=torch.float32))
-
-    target_tokens = pad_sequence(
-        [t.squeeze() if t.dim() > 1 else t for t in target_tokens_list],
-        batch_first=True,
-        padding_value=0,
-    )
-    weights = pad_sequence(weights_list, batch_first=True, padding_value=0.0)
-    batch_size = len(input_ids_list)
-    weights_device = weights.to(device)
-
-    # Temperature: verl 0.8.0 expects a 1-D (B,) tensor and unsqueezes it
-    # internally before `logits.div_(temperature)`. (verl 0.7.x expected
-    # (B,1,1) for direct broadcast, but 0.8.0 changed.) It is all-ones here, so
-    # the scaling is a no-op — the field exists only to satisfy verl's engine
-    # contract. Pin the rank/shape explicitly: the TensorDict below already
-    # checks the leading dim == batch_size, but NOT that it is 1-D, so this
-    # guards against silently regressing to the 0.7.x (B,1,1) shape (or any
-    # other rank) that a verl bump might mis-broadcast across the vocab dim.
-    temperature = torch.ones(batch_size, device=device, dtype=torch.float32)
-    assert temperature.shape == (batch_size,), (
-        f"temperature must be 1-D (B,)=({batch_size},) for verl 0.8.0's internal "
-        f"unsqueeze before logits.div_(temperature); got {tuple(temperature.shape)}. "
-        "If this fires after a verl upgrade, re-check verl's temperature handling "
-        "(see the use_remove_padding note below) before changing the shape."
-    )
-    td_dict = {
-        "target_tokens": target_tokens.to(device),
-        "weights": weights_device,
-        "loss_mask": weights_device,
-        "temperature": temperature,
-        "adapter_id": adapter_id,
-    }
-
-    # Add RLHF fields if any datum has them
-    if has_rlhf_fields:
-        logprobs_padded = pad_sequence(logprobs_list, batch_first=True, padding_value=0.0)
-        advantages_padded = pad_sequence(advantages_list, batch_first=True, padding_value=0.0)
-        td_dict["logprobs"] = logprobs_padded.to(device)
-        td_dict["advantages"] = advantages_padded.to(device)
-
-    td = TensorDict(td_dict, batch_size=batch_size)
-    td["input_ids"] = input_ids_nested
-    td["position_ids"] = position_ids_nested
-    tu.assign_non_tensor(td, global_token_num=global_token_num)
-    # v22 grad-accum: route through verl's `use_dynamic_bsz=False` path with
-    # a fixed `micro_batch_size_per_gpu`. verl's loop never zero_grad's, so
-    # gradients accumulate across all mb's; the caller's optim_step then
-    # consumes the accumulated grad and zero_grad's.
-    if micro_batch_size and micro_batch_size > 0 and batch_size % micro_batch_size == 0:
-        mb = micro_batch_size
-    else:
-        if micro_batch_size and micro_batch_size > 0:
-            logger.warning(
-                "Configured micro_batch_size=%d does not evenly divide batch_size=%d; "
-                "falling back to full batch as a single micro-batch. "
-                "This may cause OOM for large batches.",
-                micro_batch_size,
-                batch_size,
-            )
-        mb = batch_size
-    tu.assign_non_tensor(
-        td,
-        use_dynamic_bsz=False,
-        micro_batch_size_per_gpu=mb,
-        # use_remove_padding=False: we use NO_PADDING pad_mode (jagged tensors)
-        # but NOT verl's rmpad path because rmpad does
-        #   `logits_rmpad.div_(temperature)` expecting a scalar temperature,
-        # while our TensorDict-resident temperature is (B,) (see the temperature
-        # note above): it must carry a leading batch dim to pass TensorDict
-        # batch_size validation, so it can't be a bare scalar. These two
-        # constraints conflict; fixing requires monkey-patching verl's
-        # prepare_model_outputs (TODO).
-        # With False + jagged nested tensors + NO_PADDING, verl pads to
-        # max_seq_len internally, forwards, then narrows logits back per
-        # sample, so per-sample logprob lengths still equal their real
-        # input_ids lengths (verified in post-mortem replay 2026-06-09).
-        use_remove_padding=False,
-        pad_mode=DatasetPadMode.NO_PADDING,
-    )
-    return td
-
-
-def _make_verl_loss_fn(
-    loss_fn_name: str,
-    loss_fn_config: dict[str, float] | None,
-) -> Callable[..., Any]:
-    """Wrap tuft get_loss_fn to engine signature (model_output, data) -> (loss, metrics)."""
-    loss_fn_config = loss_fn_config or {}
-    tuft_loss = get_loss_fn(loss_fn_name)
-
-    # Check if this is an RLHF loss function that requires additional fields
-    rlhf_loss_fns = {"ppo", "grpo", "cispo", "importance_sampling", "dro"}
-    is_rlhf = loss_fn_name.lower() in rlhf_loss_fns
-
-    def _loss_function(
-        model_output: Dict[str, Any],
-        data: TensorDict,
-        dp_group: Any = None,
-        **kwargs: Any,
-    ) -> Any:
-        # model_output["log_probs"] is nested (B, seq); data["weights"] is (B, max_len)
-        log_probs_nt = model_output["log_probs"]
-        weights = data["weights"]
-        batch_size, max_len = weights.shape
-        # Guard (verl 0.8.0 contract): with use_remove_padding=False + NO_PADDING,
-        # verl narrows logits back per sample, so log_probs is a nested
-        # (B, per_sample_len) tensor whose batch dim must equal B (the padded
-        # (B, max_len) view below then aligns per sample). This is the same
-        # forward/narrow path that applies `logits.div_(temperature)`, so a verl
-        # upgrade that changes it trips here loudly instead of silently
-        # misaligning logprobs. (Over-length samples are already caught by
-        # to_padded_tensor's output_size.)
-        assert log_probs_nt.size(0) == batch_size, (
-            f"verl returned log_probs with batch dim {log_probs_nt.size(0)} != "
-            f"expected {batch_size}; verl's forward/temperature path may have changed — "
-            "re-verify before bumping verl past 0.8.x."
-        )
-        target_logprobs = torch.nested.to_padded_tensor(
-            log_probs_nt, padding=0.0, output_size=(batch_size, max_len)
-        )
-
-        # Build loss_fn_inputs based on loss function type
-        if is_rlhf:
-            # RLHF losses (PPO, GRPO, etc.) need logprobs and advantages
-            # Check if data has required fields
-            has_logprobs = "logprobs" in data.keys()
-            has_advantages = "advantages" in data.keys()
-
-            if not has_logprobs or not has_advantages:
-                import logging
-
-                logging.warning(
-                    f"RLHF loss '{loss_fn_name}' requires 'logprobs' and 'advantages' in data. "
-                    f"Available keys: {list(data.keys())}. "
-                    f"Using fallback values."
-                )
-
-            loss_fn_inputs = {
-                "target_logprobs": target_logprobs,
-                "logprobs": data.get("logprobs", target_logprobs)
-                if has_logprobs
-                else target_logprobs,
-                "advantages": data.get("advantages", torch.zeros_like(target_logprobs))
-                if has_advantages
-                else torch.zeros_like(target_logprobs),
-            }
-        else:
-            # Standard losses (cross_entropy) only need target_logprobs and weights
-            loss_fn_inputs = {"target_logprobs": target_logprobs, "weights": weights}
-
-        loss, metrics = tuft_loss(loss_fn_inputs, loss_fn_config)
-        return loss, metrics
-
-    return _loss_function
 
 
 def _fsdp_logprobs_to_loss_fn_outputs(
     engine_output: Dict[str, Any],
     data: list[types.Datum],
 ) -> list[Dict[str, Any]]:
-    """Extract log_probs from engine.forward_backward_batch model_output and convert to
-    per-datum loss_fn_outputs."""
+    """Convert engine log-prob tensors to per-datum Tinker outputs."""
+
     model_output = (engine_output or {}).get("model_output") or {}
-    log_probs_nt = model_output.get("log_probs")
-    if log_probs_nt is None or not hasattr(log_probs_nt, "unbind"):
-        return [
-            {"logprobs": types.TensorData(data=[0.0], dtype="float32", shape=[1])} for _ in data
-        ]
-    try:
-        # Verl returns log_probs as nested tensor (batch, variable_len); unbind(0) gives per-sample
-        per_sample = log_probs_nt.unbind(dim=0)
-        return [
-            {"logprobs": types.TensorData.from_torch(t.detach().cpu().float().clone())}
-            for t in per_sample
-        ]
-    except Exception:
-        return [
-            {"logprobs": types.TensorData(data=[0.0], dtype="float32", shape=[1])} for _ in data
-        ]
+    per_sample = model_output.get("log_probs") or []
+    if len(per_sample) != len(data):
+        raise RuntimeError(
+            f"FSDP engine returned {len(per_sample)} log-prob rows for {len(data)} datums"
+        )
+    return [
+        {"logprobs": types.TensorData.from_torch(t.detach().cpu().float().clone())}
+        for t in per_sample
+    ]
 
 
 # =============================================================================
@@ -438,15 +156,13 @@ def _get_rank_slots_from_config(config: ModelConfig) -> Dict[int, int]:
 
 
 def _config_to_worker_dict(config: ModelConfig) -> dict:
-    """ModelConfig -> serializable dict for TrainingWorkerConfig and SlotPoolConfig in actors."""
+    """Convert ModelConfig to the serializable subset needed by Ray workers."""
+
     rank_slots = _get_rank_slots_from_config(config)
     return {
         "model_path": str(config.model_path),
         "max_model_len": config.max_model_len,
-        "use_remove_padding": getattr(config, "use_remove_padding", False),
         "fsdp_override_config": dict(getattr(config, "fsdp_override_config", None) or {}),
-        # Top-level attn_implementation acts as default if fsdp_override_config does
-        # not specify one. None lets verl/transformers pick its own default.
         "attn_implementation": getattr(config, "attn_implementation", None),
         "slot_config": {
             "rank_slots": rank_slots,
@@ -456,41 +172,24 @@ def _config_to_worker_dict(config: ModelConfig) -> dict:
     }
 
 
-def _worker_dict_to_training_config(config_dict: dict) -> tuple:
-    """Build TrainingWorkerConfig and SlotPoolConfig from config_dict inside an actor."""
-    from verl.trainer.config import CheckpointConfig
-    from verl.workers.config import HFModelConfig
-    from verl.workers.config.engine import FSDPEngineConfig
-    from verl.workers.config.optimizer import OptimizerConfig
+def _worker_dict_to_configs(config_dict: dict) -> tuple[FSDPModelConfig, SlotPoolConfig]:
+    """Build the torch-native model and slot configurations inside an actor."""
 
     override = dict(config_dict.get("fsdp_override_config") or {})
-    if "attn_implementation" not in override:
-        # Resolution order: fsdp_override_config > top-level attn_implementation > "eager".
-        top_attn = config_dict.get("attn_implementation")
-        override["attn_implementation"] = top_attn or "eager"
+    attn_implementation = override.pop(
+        "attn_implementation",
+        config_dict.get("attn_implementation") or "sdpa",
+    )
     logging.getLogger(__name__).info(
         "[FSDPTrainingBackend] Loading %s with attn_implementation=%s",
         config_dict.get("model_path"),
-        override["attn_implementation"],
+        attn_implementation,
     )
-    hf_model_config = HFModelConfig(
+    model_config = FSDPModelConfig(
         path=config_dict["model_path"],
-        use_remove_padding=config_dict.get("use_remove_padding", False),
+        max_model_len=int(config_dict["max_model_len"]),
+        attn_implementation=attn_implementation,
         override_config=override,
-    )
-    engine_config = FSDPEngineConfig(
-        strategy="fsdp2",
-        use_dynamic_bsz=False,
-        max_token_len_per_gpu=config_dict["max_model_len"],
-        micro_batch_size_per_gpu=1,
-        forward_only=False,
-    )
-    training_config = TrainingWorkerConfig(
-        model_type="language_model",
-        model_config=hf_model_config,
-        engine_config=engine_config,
-        optimizer_config=OptimizerConfig(),
-        checkpoint_config=CheckpointConfig(),
     )
     sc = config_dict.get("slot_config") or {}
     slot_config = SlotPoolConfig(
@@ -498,48 +197,33 @@ def _worker_dict_to_training_config(config_dict: dict) -> tuple:
         lora_alpha_ratio=int(sc.get("lora_alpha_ratio", 2)),
         target_modules=list(sc.get("target_modules", ["q_proj", "v_proj"])),
     )
-    return training_config, slot_config
+    return model_config, slot_config
 
 
 # =============================================================================
-# MultiAdapterVerlWorker
+# MultiAdapterFSDPWorker
 # =============================================================================
-# Holds FSDPEngineWithLMHead; manages LoRA slot allocation/release; before forward_backward
-# calls set_adapter and engine.forward_backward_batch; provides per-adapter optim_step/save/load.
-# No Ray dependency. Backend holds one instance in single-process mode; in multi-GPU mode,
-# N VerlWorkerActor (Ray) instances each hold one; N processes form torch.distributed FSDP;
-# Ray handles process creation and .remote() scheduling.
+# Owns the sharded PEFT module, adapter slots, per-adapter optimizers, and checkpoints.
 # =============================================================================
 
 
-class MultiAdapterVerlWorker:
-    """
-    Multi-LoRA slots: holds engine, calls forward_backward_batch under train_mode;
-    set_adapter is called before each call to select the current PEFT active adapter.
-    """
+class MultiAdapterFSDPWorker:
+    """Own a multi-LoRA FSDP2 module and its per-adapter training state."""
 
     def __init__(
         self,
-        model_config: Any,
-        engine_config: Any,
-        optimizer_config: Any,
-        checkpoint_config: Any,
+        model_config: FSDPModelConfig,
         slot_config: SlotPoolConfig,
     ):
         self.model_config = model_config
-        self.engine_config = engine_config
-        self.optimizer_config = optimizer_config
-        self.checkpoint_config = checkpoint_config
         self.slot_config = slot_config
-        self.engine: Any = None
+        self.module: Any = None
         self._adapters: Dict[str, AdapterInfo] = {}
         self._adapters_by_rank: Dict[int, List[str]] = {}
         self._name_counter: Dict[int, int] = {}
         self._allocated: Dict[str, bool] = {}
         self._initialized = False
-        # train_mode: enter on first forward_backward, exit in leave_train_mode() (e.g. release)
-        self._train_mode_ctx: Any = None
-        self.logger = logging.getLogger(f"{__name__}.MultiAdapterVerlWorker")
+        self.logger = logging.getLogger(f"{__name__}.MultiAdapterFSDPWorker")
 
     def _generate_adapter_name(self, rank: int) -> str:
         if rank not in self._name_counter:
@@ -549,29 +233,11 @@ class MultiAdapterVerlWorker:
         return f"adapter_r{rank}_{idx}"
 
     def initialize(self) -> None:
-        """Build engine (base + materialize + PEFT adapters + FSDP v2) and create
-        per-adapter optimizers."""
+        """Build the base model, PEFT adapter pool, FSDP2 module, and first optimizer."""
+
         if self._initialized:
             return
-        base_model = self.engine._build_module()
-
-        # Materialize: meta model has no storage; load pretrained weights before .cuda()
-        model_path = getattr(self.engine.model_config, "local_path", None) or getattr(
-            self.engine.model_config, "path", None
-        )
-        if not model_path:
-            raise RuntimeError("engine.model_config has no local_path or path for materialization")
-        trust_remote = getattr(self.engine.model_config, "trust_remote_code", True)
-        full_cpu = AutoModelForCausalLM.from_pretrained(
-            model_path,
-            torch_dtype=torch.bfloat16,
-            low_cpu_mem_usage=True,
-            trust_remote_code=trust_remote,
-        )
-        state_dict = full_cpu.state_dict()
-        del full_cpu
-        base_model.load_state_dict(state_dict, assign=True, strict=False)
-        del state_dict
+        base_model = build_base_model(self.model_config)
 
         peft_model = None
         for rank, count in self.slot_config.rank_slots.items():
@@ -585,7 +251,6 @@ class MultiAdapterVerlWorker:
                     target_modules=list(self.slot_config.target_modules),
                 )
                 if peft_model is None:
-                    base_model.enable_input_require_grads()
                     peft_model = get_peft_model(
                         base_model,
                         lora_config,
@@ -636,7 +301,7 @@ class MultiAdapterVerlWorker:
         for module in wrapped_modules:
             fully_shard(module, mesh=device_mesh, mp_policy=mp_policy)
         fully_shard(model_cuda, mesh=device_mesh, mp_policy=mp_policy)
-        self.engine.module = model_cuda
+        self.module = model_cuda
         self._create_optimizer_for_adapter(first)
         self._initialized = True
 
@@ -645,15 +310,12 @@ class MultiAdapterVerlWorker:
         if info.optimizer is not None:
             return
         self._activate_adapter(adapter_name)
-        params = [p for p in self.engine.module.parameters() if p.requires_grad]
+        params = [p for p in self.module.parameters() if p.requires_grad]
         info.optimizer = torch.optim.AdamW(params, lr=1e-4, weight_decay=0.01)
 
     def _activate_adapter(self, adapter_name: str) -> None:
         """Set PEFT active adapter before computation; same as HFTrainingModel._activate_adapter."""
-        # FSDP v2 does not wrap the module, so we access the PEFT model directly
-        # For FSDP v1: self.engine.module.module.set_adapter(adapter_name)
-        # For FSDP v2: self.engine.module is the PEFT model itself
-        module = self.engine.module
+        module = self.module
         # Handle both FSDP v1 (wrapped) and FSDP v2 (not wrapped) cases
         if hasattr(module, "set_adapter"):
             module.set_adapter(adapter_name)
@@ -662,45 +324,22 @@ class MultiAdapterVerlWorker:
         else:
             raise RuntimeError(f"Cannot find set_adapter method on module: {type(module)}")
 
-    def _ensure_train_mode_entered(self) -> None:
-        """Enter train_mode once and store context; exit in leave_train_mode() (e.g. release).
-
-        We store the context instead of using 'with engine.train_mode():' because the context's
-        __exit__ (or teardown) automatically clears engine state (e.g. optimizer_zero_grad). With a
-        fine-grained SDK where forward_backward and optim_step are separate calls, exiting the
-        context after each forward would clear gradients before optim_step runs. So we enter once,
-        keep the context, and only exit explicitly in leave_train_mode() when the model is released.
-        """
-        if self._train_mode_ctx is not None:
-            return
-        ctx = self.engine.train_mode()
-        ctx.__enter__()
-        self._train_mode_ctx = ctx
-
-    def leave_train_mode(self) -> None:
-        """Exit the stored train_mode context. Call on model release to clean up Verl engine."""
-        if self._train_mode_ctx is not None:
-            self._train_mode_ctx.__exit__(None, None, None)
-            self._train_mode_ctx = None
-
     def forward_backward(
         self,
         adapter_name: str,
-        data: TensorDict,
-        loss_function: Callable[..., Any],
+        data: list[types.Datum],
+        loss_fn_name: str,
+        loss_fn_config: dict[str, float] | None,
+        micro_batch_size: int,
         forward_only: bool = False,
     ) -> Dict[str, Any]:
-        """Set PEFT active adapter, then call engine.forward_backward_batch (no step).
+        """Run forward/backward without stepping or clearing accumulated gradients.
 
         NOTE: We deliberately do NOT call optimizer.zero_grad() here. Multiple
         consecutive forward_backward calls between two optim_step calls will
         accumulate gradients (standard PyTorch grad-accumulation semantics).
         zero_grad happens inside optim_step() at the end of each training step
-        (see optim_step below, line ~662). verl `forward_backward_batch` itself
-        only calls `loss.backward()` per micro-batch and never zero_grad's.
-        verl `EngineTrainModeCtx.__exit__` does call optimizer_zero_grad, but
-        we keep that context permanently entered via `_ensure_train_mode_entered`
-        and only exit it on adapter release (`leave_train_mode`).
+        (see optim_step below).
 
         This is required for two cases:
           1. Per-call internal micro-batch accumulation (callers split a large
@@ -714,20 +353,15 @@ class MultiAdapterVerlWorker:
         info = self._adapters[adapter_name]
         if info.optimizer is None:
             self._create_optimizer_for_adapter(adapter_name)
-        self.engine.optimizer = info.optimizer
-        self._ensure_train_mode_entered()
-        output = self.engine.forward_backward_batch(
-            data=data,
-            loss_function=loss_function,
+        self.module.train()
+        return fsdp_forward_backward(
+            self.module,
+            data,
+            loss_fn_name,
+            loss_fn_config,
+            micro_batch_size,
             forward_only=forward_only,
         )
-        return output
-
-    def _zero_grad_for_adapter(self, adapter_name: str) -> None:
-        _match = f".{adapter_name}."
-        for name, param in self.engine.module.named_parameters():
-            if _match in name and param.grad is not None:
-                param.grad = None
 
     def optim_step(
         self,
@@ -748,17 +382,10 @@ class MultiAdapterVerlWorker:
             for pg in opt.param_groups:
                 pg["weight_decay"] = weight_decay
         if grad_clip_norm is not None and grad_clip_norm > 0:
-            torch.nn.utils.clip_grad_norm_(self.engine.module.parameters(), grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(self.module.parameters(), grad_clip_norm)
         opt.step()
         opt.zero_grad()
         info.step_count += 1
-        self.engine.to(
-            "cpu",
-            model=self.engine.is_param_offload_enabled,
-            optimizer=self.engine.is_optimizer_offload_enabled,
-            grad=self.engine.is_param_offload_enabled,
-        )
-        self.engine.mode = None
         return {"step_count": info.step_count, "adapter": adapter_name}
 
     def save_checkpoint(self, adapter_name: str, path: str | Path, optimizer: bool = True) -> None:
@@ -771,7 +398,7 @@ class MultiAdapterVerlWorker:
         # Collect full state dict for the adapter
         state = {}
         _match = f".{adapter_name}."
-        for name, param in self.engine.module.named_parameters():
+        for name, param in self.module.named_parameters():
             if _match in name:
                 if isinstance(param, DTensor):
                     # FSDP v2: gather full tensor from all ranks
@@ -811,7 +438,7 @@ class MultiAdapterVerlWorker:
             # so sampling/VLLM can load
             # FSDP v2: PEFT's save_pretrained cannot handle DTensor directly.
             # We manually save the adapter config and weights in PEFT format.
-            module = self.engine.module
+            module = self.module
             has_nested_peft = hasattr(module, "module") and hasattr(module.module, "peft_config")
             peft_model = module.module if has_nested_peft else module
 
@@ -856,7 +483,7 @@ class MultiAdapterVerlWorker:
         self._activate_adapter(adapter_name)
         with torch.no_grad():
             _match = f".{adapter_name}."
-            for name, param in self.engine.module.named_parameters():
+            for name, param in self.module.named_parameters():
                 if _match in name and name in state:
                     loaded_tensor = state[name]
                     if isinstance(param, DTensor):
@@ -904,20 +531,20 @@ class MultiAdapterVerlWorker:
 
 
 # =============================================================================
-# VerlWorkerActor: Ray actor, one GPU per process, forms torch.distributed with peers
+# FSDPWorkerActor: Ray actor, one GPU per process, forms torch.distributed with peers
 # =============================================================================
 
 
-class VerlWorkerActor:
+class FSDPWorkerActor:
     """Single-GPU Ray actor; N form process group via init_dist, each holds one worker."""
 
     def __init__(self, rank: int, world_size: int, config_dict: dict) -> None:
         self.rank = rank
         self.world_size = world_size
         self.config_dict = config_dict
-        self._worker: Optional[MultiAdapterVerlWorker] = None
+        self._worker: Optional[MultiAdapterFSDPWorker] = None
         self._dist_initialized = False
-        self.logger = logging.getLogger(f"{__name__}.VerlWorkerActor")
+        self.logger = logging.getLogger(f"{__name__}.FSDPWorkerActor")
 
     def get_node_ip(self) -> str:
         import ray
@@ -953,21 +580,11 @@ class VerlWorkerActor:
     def build_worker(self) -> None:
         if self._worker is not None:
             return
-        training_config, slot_config = _worker_dict_to_training_config(self.config_dict)
-        engine = FSDPEngineWithLMHead(
-            model_config=training_config.model_config,  # pyright: ignore[reportCallIssue]
-            engine_config=training_config.engine_config,  # pyright: ignore[reportCallIssue]
-            optimizer_config=training_config.optimizer_config,  # pyright: ignore[reportCallIssue]
-            checkpoint_config=training_config.checkpoint_config,  # pyright: ignore[reportCallIssue]
-        )
-        self._worker = MultiAdapterVerlWorker(
-            model_config=training_config.model_config,
-            engine_config=training_config.engine_config,
-            optimizer_config=training_config.optimizer_config,
-            checkpoint_config=training_config.checkpoint_config,
+        model_config, slot_config = _worker_dict_to_configs(self.config_dict)
+        self._worker = MultiAdapterFSDPWorker(
+            model_config=model_config,
             slot_config=slot_config,
         )
-        self._worker.engine = engine
         logging.info("[SERVER][Actor] build_worker 调用 initialize 前 rank=%s", self.rank)
         self._worker.initialize()
         logging.info("[SERVER][Actor] build_worker initialize 返回 rank=%s", self.rank)
@@ -994,15 +611,10 @@ class VerlWorkerActor:
 
         data: list[types.Datum] (or dicts after Ray serialization).
 
-        Grad-accum strategy (v22): we issue **a single** verl
-        `forward_backward_batch` call per RPC, passing `micro_batch_size`
-        through the TensorDict's `micro_batch_size_per_gpu` non-tensor.
-        verl then splits the shard into `len(data) // micro_batch_size`
-        micro-batches and accumulates gradients across them (verl's loop
-        never zero_grad's). This keeps NCCL collective count per RPC
-        constant across dp ranks (1 batch_num_tokens all_reduce + 1
-        same_micro_num_in_dp sync), avoiding the dp-imbalance hang we hit
-        when the actor itself looped multiple verl calls per RPC.
+        The torch-native engine splits this shard into contiguous micro-batches
+        and accumulates gradients without stepping or clearing them. The caller
+        guarantees every rank runs the same number of micro-batches so FSDP2
+        collectives remain symmetric.
 
         Caller is responsible for invoking `optim_step` afterwards
         (which will step + zero_grad).
@@ -1016,29 +628,22 @@ class VerlWorkerActor:
                 "loss_fn_outputs": [],
             }
 
-        # mb honored only when it cleanly divides len(data); otherwise we
-        # fall back to mb=len(data) (single micro-batch) to keep verl
-        # `chunk_tensordict` happy (it asserts len % chunks == 0).
+        # Keep a single micro-batch when the configured size does not divide
+        # the shard. The backend applies the same fallback on every rank.
         if micro_batch_size and micro_batch_size > 0 and len(data) % micro_batch_size == 0:
             mb = micro_batch_size
         else:
             mb = len(data)
         n_micro = len(data) // mb
-        loss_fn = _make_verl_loss_fn(loss_fn_name, loss_fn_config)
-
-        def _to_scalar(v: Any) -> Any:
-            if isinstance(v, list) and v and all(isinstance(x, (int, float)) for x in v):
-                return sum(v) if len(v) > 1 else float(v[0])
-            return v
-
-        td = _datum_list_to_tensordict(data, adapter_name, "cuda", micro_batch_size=mb)
         out = self._worker.forward_backward(
             adapter_name,
-            td,
-            loss_fn,
+            data,
+            loss_fn_name,
+            loss_fn_config,
+            mb,
             forward_only=forward_only,
         )
-        metrics = {k: _to_scalar(v) for k, v in (out.get("metrics") or {}).items()}
+        metrics = dict(out.get("metrics") or {})
         metrics["actor/num_micro_batches"] = float(n_micro)
         all_outputs = _fsdp_logprobs_to_loss_fn_outputs(out, data)
 
@@ -1069,15 +674,10 @@ class VerlWorkerActor:
             return
         self._worker.load_checkpoint(adapter_name, Path(path), optimizer)
 
-    def leave_train_mode(self) -> None:
-        """Exit train_mode context on this actor; call on model release."""
-        if self._worker is not None:
-            self._worker.leave_train_mode()
-
 
 # =============================================================================
 # FSDPTrainingBackend (implements BaseTrainingBackend)
-# Multi-GPU: N GPUs = N VerlWorkerActor (Ray), forming torch.distributed.
+# Multi-GPU: N GPUs = N FSDPWorkerActor processes, forming torch.distributed.
 # =============================================================================
 
 
@@ -1085,7 +685,7 @@ class FSDPTrainingBackend(BaseTrainingBackend):
     """
     Multi-node/multi-GPU training backend; peer to HFTrainingBackend.
     Selected via ModelConfig.training_backend = "fsdp".
-    Uses N VerlWorkerActor (Ray), one per GPU, forming a process group for FSDP.
+    Uses one Ray actor per GPU, forming a process group for FSDP2.
     """
 
     def __init__(
@@ -1097,7 +697,7 @@ class FSDPTrainingBackend(BaseTrainingBackend):
         super().__init__(config)
         self._fsdp_index = fsdp_index  # Index among FSDP models; port = base + fsdp_index
         self._worker_venv_path = worker_venv_path
-        self._worker: Optional[MultiAdapterVerlWorker] = None
+        self._worker: Optional[MultiAdapterFSDPWorker] = None
         self._actors: List[Any] = []
         self._world_size: int = 0
         self._lora_id_to_adapter_name: Dict[str, str] = {}
@@ -1155,21 +755,11 @@ class FSDPTrainingBackend(BaseTrainingBackend):
                     rank=0,
                     world_size=1,
                 )
-            training_config, _slot = _worker_dict_to_training_config(self._config_dict)
-            engine = FSDPEngineWithLMHead(
-                model_config=training_config.model_config,  # pyright: ignore[reportCallIssue]
-                engine_config=training_config.engine_config,  # pyright: ignore[reportCallIssue]  # pyright: ignore[reportCallIssue]
-                optimizer_config=training_config.optimizer_config,  # pyright: ignore[reportCallIssue]  # pyright: ignore[reportCallIssue]
-                checkpoint_config=training_config.checkpoint_config,  # pyright: ignore[reportCallIssue]  # pyright: ignore[reportCallIssue]
-            )
-            self._worker = MultiAdapterVerlWorker(
-                model_config=training_config.model_config,
-                engine_config=training_config.engine_config,
-                optimizer_config=training_config.optimizer_config,
-                checkpoint_config=training_config.checkpoint_config,
+            model_config, _slot = _worker_dict_to_configs(self._config_dict)
+            self._worker = MultiAdapterFSDPWorker(
+                model_config=model_config,
                 slot_config=self._slot_config,
             )
-            self._worker.engine = engine
             await asyncio.to_thread(self._worker.initialize)
             self._world_size = 1
             return
@@ -1199,7 +789,7 @@ class FSDPTrainingBackend(BaseTrainingBackend):
         actors = []
         for r in range(n_gpus):
             actor = (
-                ray.remote(VerlWorkerActor)
+                ray.remote(FSDPWorkerActor)
                 .options(
                     num_gpus=1,
                     runtime_env=_runtime_env,
@@ -1275,15 +865,11 @@ class FSDPTrainingBackend(BaseTrainingBackend):
                 self._adapter_name_to_lora_id.pop(adapter_name, None)
                 if self._worker is not None:
                     self._worker.release_slot(adapter_name)
-                    self._worker.leave_train_mode()
                 elif self._actors:
                     import ray
 
                     await asyncio.to_thread(
                         ray.get, self._actors[0].release_slot.remote(adapter_name)
-                    )
-                    await asyncio.to_thread(
-                        ray.get, [a.leave_train_mode.remote() for a in self._actors]
                     )
 
     async def forward(
@@ -1305,7 +891,7 @@ class FSDPTrainingBackend(BaseTrainingBackend):
         # < shard length), each call splits its (sharded) batch into
         # ceil(len/mb) micro-batches. Each micro-batch runs a full
         # forward+backward, and gradients accumulate across micro-batches
-        # because MultiAdapterVerlWorker.forward_backward no longer zero_grad's
+        # because MultiAdapterFSDPWorker.forward_backward never zero_grad's
         # at entry. The final optim_step (called by the user) consumes the
         # accumulated gradients and zero_grad's.
         #
@@ -1316,33 +902,22 @@ class FSDPTrainingBackend(BaseTrainingBackend):
         # eliminating mini-batch SGD intra-step off-policy drift in PPO/GRPO.
         mb = int(getattr(self.config, "micro_batch_size", 0) or 0)
 
-        def _to_scalar(v: Any) -> Any:
-            if isinstance(v, list) and v and all(isinstance(x, (int, float)) for x in v):
-                return sum(v) if len(v) > 1 else float(v[0])
-            return v
-
         if self._worker is not None:
-            verl_loss_fn = _make_verl_loss_fn(loss_fn_name, loss_fn_config)
-            # Single-worker (single GPU) path: trust verl's
-            # `forward_backward_batch` to internally split into mb-sized
-            # micro-batches and accumulate gradients (mirrors the multi-actor
-            # path; see VerlWorkerActor.forward_backward).
             if mb > 0 and len(data) % mb == 0:
                 eff_mb = mb
             else:
                 eff_mb = max(len(data), 1)
             n_micro = max(len(data) // eff_mb, 1) if data else 0
-            td = await asyncio.to_thread(
-                _datum_list_to_tensordict, data, adapter_name, "cuda", eff_mb
-            )
             out = await asyncio.to_thread(
                 self._worker.forward_backward,
                 adapter_name,
-                td,
-                verl_loss_fn,
-                not backward,
+                data,
+                loss_fn_name,
+                loss_fn_config,
+                eff_mb,
+                forward_only=not backward,
             )
-            metrics = {k: _to_scalar(v) for k, v in (out.get("metrics") or {}).items()}
+            metrics = dict(out.get("metrics") or {})
             metrics["actor/num_micro_batches"] = float(n_micro)
             loss_fn_outputs = _fsdp_logprobs_to_loss_fn_outputs(out, data)
         else:

--- a/src/tuft/backends/vllm_worker.py
+++ b/src/tuft/backends/vllm_worker.py
@@ -3,7 +3,7 @@
 Adapted from Trinity-RFT (``trinity/common/models/vllm_worker.py`` and
 ``trinity/common/models/vllm_patch/worker_patch.py``, Apache-2.0,
 https://github.com/agentscope-ai/Trinity-RFT), with the weight-sync pieces
-(verl MoE weight-loader patch, checkpoint weight-transfer engine) removed --
+(MoE weight-loader patch and checkpoint weight-transfer engine) removed --
 TuFT delivers trained weights to the sampler as on-disk LoRA adapters and
 never syncs full model weights into vLLM.
 

--- a/src/tuft/config.py
+++ b/src/tuft/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -62,7 +62,7 @@ class ModelConfig(BaseModel):
     # default training setting
     micro_batch_size: int = 1  # micro-batch size for training
     # training backend: "hf" (HFTrainingBackend) or "fsdp" (FSDPTrainingBackend)
-    training_backend: str = "hf"
+    training_backend: Literal["hf", "fsdp"] = "hf"
     # number of GPUs (Ray actors) for FSDP backend; default 1.
     # Multi-GPU (fsdp_num_gpus >= 2) uses contiguous batch sharding across
     # Ray actors; each actor runs FSDP-2 with micro-batch grad accumulation.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,25 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from tuft import cli
 from tuft.config import AppConfig, ModelConfig
+
+
+def test_model_config_rejects_unknown_training_backend() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        ModelConfig.model_validate(
+            {
+                "model_name": "test-model",
+                "model_path": "/path/to/model",
+                "max_model_len": 1024,
+                "training_backend": "unknown",
+            }
+        )
+
+    assert exc_info.value.errors()[0]["loc"] == ("training_backend",)
 
 
 def test_start_passes_config(monkeypatch, tmp_path) -> None:

--- a/tests/test_fsdp_training_backend.py
+++ b/tests/test_fsdp_training_backend.py
@@ -258,6 +258,64 @@ def test_forward_backward_micro_batches_preserve_summed_gradients():
     assert all(parameter.grad is None for parameter in forward_only_model.parameters())
 
 
+@pytest.mark.asyncio
+async def test_fsdp_engine_matches_hf_target_tokens_on_cpu():
+    from types import SimpleNamespace
+
+    import torch
+
+    from tuft.backends.fsdp_engine import forward_backward
+    from tuft.backends.hf_training_model import HFTrainingModel
+    from tuft.loss_fn import get_loss_fn
+
+    class PositionIndependentLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.scale = torch.nn.Parameter(torch.tensor(1.0))
+
+        def forward(self, input_ids, **_kwargs):
+            batch, seq_len = input_ids.shape
+            vocab_logits = self.scale * torch.arange(16, dtype=torch.float32)
+            logits = vocab_logits.expand(batch, seq_len, -1).clone()
+            return SimpleNamespace(logits=logits)
+
+    data = [
+        types.Datum(
+            model_input=types.ModelInput.from_ints(tokens=[10, 11]),
+            loss_fn_inputs={
+                "target_tokens": types.TensorData(data=[11, 12], dtype="int64"),
+                "weights": types.TensorData(data=[1.0, 1.0], dtype="float32"),
+            },
+        )
+    ]
+
+    hf_model = HFTrainingModel.__new__(HFTrainingModel)
+    hf_model.model = PositionIndependentLM()  # type: ignore[assignment]
+    hf_loss, hf_metrics, hf_outputs = await hf_model._forward_micro_batch(
+        data,
+        get_loss_fn("cross_entropy"),
+        loss_fn_config=None,
+        backward=False,
+    )
+
+    fsdp_model = PositionIndependentLM()
+    fsdp_out = forward_backward(
+        fsdp_model,
+        data,
+        "cross_entropy",
+        None,
+        micro_batch_size=1,
+        forward_only=True,
+    )
+
+    torch.testing.assert_close(
+        fsdp_out["model_output"]["log_probs"][0],
+        hf_outputs[0]["logprobs"].to_torch(),
+    )
+    assert fsdp_out["metrics"]["loss:sum"] == pytest.approx(hf_metrics["loss:sum"])
+    assert fsdp_out["metrics"]["loss:sum"] == pytest.approx(hf_loss)
+
+
 # -----------------------------------------------------------------------------
 # Integration tests: FSDP backend single-process (GPU, TUFT_TEST_MODEL)
 # -----------------------------------------------------------------------------

--- a/tests/test_fsdp_training_backend.py
+++ b/tests/test_fsdp_training_backend.py
@@ -2,8 +2,8 @@
 Unit and integration tests for FSDP training backend.
 
 Unit tests (no GPU):
-  - Config/slot helpers and async_init validation (no torch/verl).
-  - Tensordict and loss adapters (torch/tensordict on CPU).
+  - Config/slot helpers and async_init validation.
+  - Torch-native batching, log-prob extraction, and gradient accumulation on CPU.
 
 Integration tests (GPU, optional TUFT_TEST_MODEL):
   - FSDPTrainingBackend single-process: create_adapter, forward, optim_step, save/load.
@@ -26,7 +26,7 @@ from tuft.config import ModelConfig
 
 
 # -----------------------------------------------------------------------------
-# Unit tests: config and slot (no GPU, no torch/verl)
+# Unit tests: config and slot (no GPU)
 # -----------------------------------------------------------------------------
 
 
@@ -131,89 +131,131 @@ def test_fsdp_port_allocation_by_index():
 
 
 # -----------------------------------------------------------------------------
-# Unit tests: tensordict and loss adapters (torch/tensordict, CPU)
+# Unit tests: torch-native FSDP engine (CPU)
 # -----------------------------------------------------------------------------
 
 
-def test_chunk_tensordict_allow_2d_nested():
-    """_chunk_tensordict_allow_2d_nested splits TensorDict into N chunks; 2D nested use unbind."""
+def test_prepare_micro_batch_uses_length_masks_and_flat_rolled_labels():
+    from tuft.backends.fsdp_engine import _prepare_micro_batch
+
+    data = [
+        types.Datum(
+            model_input=types.ModelInput.from_ints(tokens=[0, 2, 3]),
+            loss_fn_inputs={},
+        ),
+        types.Datum(
+            model_input=types.ModelInput.from_ints(tokens=[4, 5]),
+            loss_fn_inputs={},
+        ),
+    ]
+    batch = _prepare_micro_batch(data, "cpu")
+    assert batch.input_ids.tolist() == [[0, 2, 3], [4, 5, 0]]
+    # Token id 0 is real in row 0; padding is derived from lengths, not token values.
+    assert batch.attention_mask.tolist() == [[1, 1, 1], [1, 1, 0]]
+    assert batch.position_ids.tolist() == [[0, 1, 2], [0, 1, 2]]
+    # roll([0, 2, 3, 4, 5], -1) -> [2, 3, 4, 5, 0]
+    assert batch.labels.tolist() == [[2, 3, 4], [5, 0, 0]]
+    assert batch.lengths == [3, 2]
+
+
+def test_prepare_loss_inputs_pads_weights_and_defaults_missing_rows():
     import torch
-    from tensordict import TensorDict
 
-    from tuft.backends.fsdp_training_backend import _chunk_tensordict_allow_2d_nested
-
-    # Build a small TensorDict: 4 rows, one regular key, one 2D nested
-    batch_size = 4
-    a = torch.arange(8, dtype=torch.float32).reshape(4, 2)
-    nested = torch.nested.nested_tensor(
-        [
-            torch.tensor([1.0, 2.0]),
-            torch.tensor([1.0]),
-            torch.tensor([1.0, 2.0, 3.0]),
-            torch.tensor([1.0]),
-        ],
-        dtype=torch.float32,
-    )
-    td = TensorDict({"a": a, "n": nested}, batch_size=[batch_size])
-    chunks = _chunk_tensordict_allow_2d_nested(td, chunks=2)
-    assert len(chunks) == 2
-    assert chunks[0]["a"].shape == (2, 2)
-    assert chunks[1]["a"].shape == (2, 2)
-    assert chunks[0]["n"].is_nested and chunks[1]["n"].is_nested
-
-
-def test_datum_list_to_tensordict_keys_and_shapes():
-    """_datum_list_to_tensordict yields TensorDict with expected keys and nested ids."""
-    from tuft.backends.fsdp_training_backend import _datum_list_to_tensordict
+    from tuft.backends.fsdp_engine import _prepare_loss_fn_inputs
 
     data = [
         types.Datum(
             model_input=types.ModelInput.from_ints(tokens=[1, 2, 3]),
-            loss_fn_inputs=dict(
-                weights=types.TensorData(data=[0.0, 1.0, 1.0], dtype="float32"),
-                target_tokens=types.TensorData(data=[2, 3, 4], dtype="int64"),
-            ),
+            loss_fn_inputs={"weights": types.TensorData(data=[0.0, 1.0, 0.0], dtype="float32")},
         ),
         types.Datum(
-            model_input=types.ModelInput.from_ints(tokens=[5, 6]),
-            loss_fn_inputs=dict(
-                weights=types.TensorData(data=[1.0, 1.0], dtype="float32"),
-                target_tokens=types.TensorData(data=[6, 7], dtype="int64"),
-            ),
+            model_input=types.ModelInput.from_ints(tokens=[4, 5]),
+            loss_fn_inputs={},
         ),
     ]
-    td = _datum_list_to_tensordict(data, adapter_id="a1", device="cpu")
-    assert td.batch_size[0] == 2
-    assert "input_ids" in td
-    assert "position_ids" in td
-    assert "weights" in td
-    assert "target_tokens" in td
-    assert "adapter_id" in td
-    assert getattr(td["input_ids"], "is_nested", False) or td["input_ids"].dim() >= 1
-    assert td["weights"].shape[0] == 2
+    target_logprobs = torch.randn(2, 3, requires_grad=True)
+    inputs = _prepare_loss_fn_inputs(data, target_logprobs, "cross_entropy")
+    assert inputs["target_logprobs"] is target_logprobs
+    assert inputs["weights"].tolist() == [[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]
 
 
-def test_make_verl_loss_fn_signature():
-    """_make_verl_loss_fn returns (model_output, data) -> (loss, metrics) callable."""
+def test_compute_target_logprobs_matches_log_softmax():
     import torch
-    from tensordict import TensorDict
 
-    from tuft.backends.fsdp_training_backend import _make_verl_loss_fn
+    from tuft.backends.fsdp_engine import _compute_target_logprobs
 
-    loss_fn = _make_verl_loss_fn("cross_entropy", {})
-    batch_size, max_len = 2, 3
-    # Engine passes nested log_probs (B, seq) as 2D nested; each row is 1D variable-length
-    log_probs = torch.randn(batch_size, max_len)
-    log_probs_nt = torch.nested.as_nested_tensor(
-        [log_probs[i] for i in range(batch_size)],
-        layout=torch.jagged,
+    torch.manual_seed(7)
+    logits = torch.randn(2, 4, 11)
+    labels = torch.randint(0, 11, (2, 4))
+    expected = torch.log_softmax(logits, dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
+    actual = _compute_target_logprobs(logits, labels)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_forward_backward_micro_batches_preserve_summed_gradients():
+    import copy
+    from types import SimpleNamespace
+
+    import torch
+
+    from tuft.backends.fsdp_engine import forward_backward
+
+    class TinyCausalLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = torch.nn.Embedding(16, 8)
+            self.lm_head = torch.nn.Linear(8, 16, bias=False)
+
+        def forward(self, input_ids, **_kwargs):
+            return SimpleNamespace(logits=self.lm_head(self.embed(input_ids)))
+
+    data = []
+    for tokens in ([1, 2, 3, 4], [5, 6], [7, 8, 9], [10, 11, 12, 13]):
+        weights = [1.0] * (len(tokens) - 1) + [0.0]
+        data.append(
+            types.Datum(
+                model_input=types.ModelInput.from_ints(tokens=list(tokens)),
+                loss_fn_inputs={"weights": types.TensorData(data=weights, dtype="float32")},
+            )
+        )
+
+    torch.manual_seed(11)
+    full_batch_model = TinyCausalLM()
+    micro_batch_model = copy.deepcopy(full_batch_model)
+    full = forward_backward(
+        full_batch_model,
+        data,
+        "cross_entropy",
+        None,
+        micro_batch_size=4,
     )
-    weights = torch.ones(batch_size, max_len)
-    data = TensorDict({"weights": weights}, batch_size=[batch_size])
-    loss, metrics = loss_fn(model_output={"log_probs": log_probs_nt}, data=data)
-    assert isinstance(loss, torch.Tensor) and loss.dim() == 0
-    assert isinstance(metrics, dict)
-    assert "loss:sum" in metrics or "loss" in str(metrics)
+    micro = forward_backward(
+        micro_batch_model,
+        data,
+        "cross_entropy",
+        None,
+        micro_batch_size=2,
+    )
+
+    assert micro["metrics"]["loss:sum"] == pytest.approx(full["metrics"]["loss:sum"])
+    for full_param, micro_param in zip(
+        full_batch_model.parameters(), micro_batch_model.parameters(), strict=True
+    ):
+        torch.testing.assert_close(micro_param.grad, full_param.grad)
+    assert [len(row) for row in micro["model_output"]["log_probs"]] == [4, 2, 3, 4]
+
+    forward_only_model = copy.deepcopy(full_batch_model)
+    for parameter in forward_only_model.parameters():
+        parameter.grad = None
+    forward_backward(
+        forward_only_model,
+        data,
+        "cross_entropy",
+        None,
+        micro_batch_size=2,
+        forward_only=True,
+    )
+    assert all(parameter.grad is None for parameter in forward_only_model.parameters())
 
 
 # -----------------------------------------------------------------------------
@@ -398,7 +440,7 @@ def test_shard_list_batch_order_contract_with_variable_length_data():
         shard_outputs = []
         for datum in shard:
             # Each actor returns logprob of length == len(tokens)
-            # (simulates verl engine returning per-token logprobs)
+            # Simulate the FSDP engine returning per-token logprobs.
             shard_outputs.append({"logprobs_len": len(datum["tokens"]), "datum_id": datum["id"]})
         all_outputs.extend(shard_outputs)
 

--- a/tests/test_training_backend.py
+++ b/tests/test_training_backend.py
@@ -73,6 +73,265 @@ def _construct_data(name: str = "extended") -> List[types.Datum]:
     return data
 
 
+LOGPROB_MEAN_REL_DIFF_PCT_TOL = 10.0
+
+
+def _construct_single_lora_logprob_datum(tokenizer) -> tuple[list[types.Datum], list[int]]:
+    prompt = "English: banana split\nPig Latin:"
+    completion = " anana-bay plit-say\n\n"
+    prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+    completion_tokens = tokenizer.encode(completion, add_special_tokens=False)
+    tokens = prompt_tokens + completion_tokens
+    input_tokens = tokens[:-1]
+    target_tokens = tokens[1:]
+    data = [
+        types.Datum(
+            model_input=types.ModelInput.from_ints(tokens=input_tokens),
+            loss_fn_inputs={
+                "target_tokens": types.TensorData(data=target_tokens, dtype="int64"),
+                "weights": types.TensorData(
+                    data=[1.0] * len(target_tokens),
+                    dtype="float32",
+                ),
+            },
+        )
+    ]
+    return data, tokens
+
+
+def _checkpoint_record(temp_dir: Path, checkpoint_id: str) -> CheckpointRecord:
+    return CheckpointRecord(
+        checkpoint_id=checkpoint_id,
+        owner_name="default",
+        checkpoint_type="training",
+        path=temp_dir / checkpoint_id,
+        training_run_id="test_logprob_run",
+        size_bytes=0,
+    )
+
+
+async def _create_training_backend_for_logprob_check(model_config: ModelConfig, backend_name: str):
+    if backend_name == "hfpeft":
+        return HFTrainingBackend(model_config)
+    if backend_name == "fsdp":
+        from tuft.backends.fsdp_training_backend import FSDPTrainingBackend
+
+        return FSDPTrainingBackend(model_config)
+    raise ValueError(f"Unknown backend: {backend_name}")
+
+
+async def _trained_lora_training_logprobs(training_backend, data: list[types.Datum]) -> np.ndarray:
+    await training_backend.create_adapter("test_lora", types.LoraConfig(rank=8, seed=42))
+    for _step in range(2):
+        await training_backend.forward(
+            data=data,
+            lora_id="test_lora",
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+            backward=True,
+        )
+        await training_backend.optim_step(types.AdamParams(learning_rate=1e-4), lora_id="test_lora")
+    outputs = await training_backend.forward(
+        data=data,
+        lora_id="test_lora",
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+        backward=False,
+    )
+    return np.asarray(outputs.loss_fn_outputs[0]["logprobs"].tolist(), dtype=np.float32)
+
+
+async def _vllm_lora_prompt_logprobs(
+    model_config: ModelConfig,
+    checkpoint: CheckpointRecord,
+    tokens: list[int],
+):
+    from tuft.backends.sampling_backend import VLLMSamplingBackend
+
+    sampling_backend = VLLMSamplingBackend(model_config)
+    try:
+        await sampling_backend.async_init()
+        await sampling_backend.add_adapter("test_lora", checkpoint.adapter_path)
+        response = await sampling_backend.sample(
+            prompt=types.ModelInput.from_ints(tokens),
+            num_samples=1,
+            sampling_params=types.SamplingParams(
+                max_tokens=1,
+                temperature=1.0,
+                top_p=1.0,
+            ),
+            include_prompt_logprobs=True,
+            lora_id="test_lora",
+        )
+    finally:
+        await sampling_backend.shutdown()
+
+    assert response.prompt_logprobs is not None
+    prompt_logprobs = response.prompt_logprobs[1:]
+    assert all(logprob is not None for logprob in prompt_logprobs)
+    return np.asarray(prompt_logprobs, dtype=np.float32)
+
+
+def _logprob_mismatch_stats(
+    training_logprobs: np.ndarray,
+    sampling_logprobs: np.ndarray,
+) -> dict[str, float]:
+    assert training_logprobs.shape == sampling_logprobs.shape
+    abs_diff = np.abs(training_logprobs - sampling_logprobs)
+    rel_diff_pct = abs_diff / np.maximum(np.abs(sampling_logprobs), 1e-6) * 100.0
+    return {
+        "mean_abs_diff": float(abs_diff.mean()),
+        "max_abs_diff": float(abs_diff.max()),
+        "mean_rel_diff_pct": float(rel_diff_pct.mean()),
+        "max_rel_diff_pct": float(rel_diff_pct.max()),
+    }
+
+
+def _assert_logprobs_close(
+    training_logprobs: np.ndarray,
+    sampling_logprobs: np.ndarray,
+    *,
+    label: str,
+) -> None:
+    stats = _logprob_mismatch_stats(training_logprobs, sampling_logprobs)
+    print(
+        "[lora-logprob-mismatch] "
+        f"{label}: "
+        f"mean_abs={stats['mean_abs_diff']:.6f}, "
+        f"max_abs={stats['max_abs_diff']:.6f}, "
+        f"mean_pct={stats['mean_rel_diff_pct']:.4f}%, "
+        f"max_pct={stats['max_rel_diff_pct']:.4f}%",
+        flush=True,
+    )
+    assert stats["mean_rel_diff_pct"] <= LOGPROB_MEAN_REL_DIFF_PCT_TOL, (
+        "training/vLLM LoRA prompt-average logprob mismatch exceeds "
+        f"{LOGPROB_MEAN_REL_DIFF_PCT_TOL:.1f}% for {label}: "
+        f"mean pct={stats['mean_rel_diff_pct']:.4f}%; "
+        f"max pct={stats['max_rel_diff_pct']:.4f}%; "
+        f"mean abs diff={stats['mean_abs_diff']:.4f}; "
+        f"max abs diff={stats['max_abs_diff']:.4f}"
+    )
+
+
+def _fsdp_logprob_gpu_counts(device_count: int) -> list[int]:
+    gpu_counts = [1]
+    fsdp_num_gpus = 2
+    while fsdp_num_gpus <= device_count:
+        gpu_counts.append(fsdp_num_gpus)
+        fsdp_num_gpus *= 2
+    return gpu_counts
+
+
+async def _run_lora_logprob_match_case(
+    *,
+    backend_name: str,
+    fsdp_num_gpus: int,
+    model_path: Path,
+    tokenizer,
+):
+    import torch
+
+    label = f"backend={backend_name}, fsdp_num_gpus={fsdp_num_gpus}"
+    model_config = ModelConfig(
+        model_name=f"Qwen/Qwen3-0.6B-logprob-{backend_name}-{fsdp_num_gpus}gpu",
+        model_path=model_path,
+        max_model_len=512,
+        tensor_parallel_size=1,
+        max_lora_rank=8,
+        training_backend="fsdp" if backend_name == "fsdp" else "hf",
+        fsdp_num_gpus=fsdp_num_gpus,
+        sampling_memory_fraction=0.5,
+    )
+    single_data, tokens = _construct_single_lora_logprob_datum(tokenizer)
+    data = single_data * fsdp_num_gpus if backend_name == "fsdp" else single_data
+
+    prev_no_ray = os.environ.get("TUFT_FSDP_NO_RAY")
+    if backend_name == "fsdp" and fsdp_num_gpus == 1:
+        os.environ["TUFT_FSDP_NO_RAY"] = "1"
+    elif backend_name == "fsdp":
+        os.environ.pop("TUFT_FSDP_NO_RAY", None)
+
+    training_backend = None
+    try:
+        training_backend = await _create_training_backend_for_logprob_check(
+            model_config,
+            backend_name,
+        )
+        await training_backend.async_init()
+        training_logprobs = await _trained_lora_training_logprobs(training_backend, data)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            checkpoint = _checkpoint_record(
+                Path(tmpdirname),
+                f"{backend_name}_{fsdp_num_gpus}gpu_test_lora",
+            )
+            await training_backend.save_state(
+                lora_id="test_lora",
+                checkpoint_record=checkpoint,
+                optimizer=False,
+            )
+            await training_backend.shutdown()
+            training_backend = None
+            torch.cuda.empty_cache()
+
+            sampling_logprobs = await _vllm_lora_prompt_logprobs(
+                model_config,
+                checkpoint,
+                tokens,
+            )
+
+        _assert_logprobs_close(training_logprobs, sampling_logprobs, label=label)
+
+    finally:
+        if training_backend is not None:
+            await training_backend.shutdown()
+        if backend_name == "fsdp":
+            if prev_no_ray is None:
+                os.environ.pop("TUFT_FSDP_NO_RAY", None)
+            else:
+                os.environ["TUFT_FSDP_NO_RAY"] = prev_no_ray
+        torch.cuda.empty_cache()
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_name", ["hfpeft", "fsdp"])
+async def test_lora_training_logprobs_match_vllm_sampling(backend_name: str, ray_cluster):
+    import torch
+
+    if "TUFT_TEST_MODEL" not in os.environ:
+        pytest.skip("Set TUFT_TEST_MODEL for LoRA logprob consistency test")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available, skipping vLLM logprob consistency test")
+
+    model_path = Path(os.environ.get("TUFT_TEST_MODEL", "Qwen/Qwen3-0.6B"))
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
+    cuda_device_count = torch.cuda.device_count()
+
+    if backend_name == "hfpeft":
+        await _run_lora_logprob_match_case(
+            backend_name=backend_name,
+            fsdp_num_gpus=1,
+            model_path=model_path,
+            tokenizer=tokenizer,
+        )
+        return
+
+    fsdp_gpu_counts = _fsdp_logprob_gpu_counts(cuda_device_count)
+    print(
+        "[lora-logprob-mismatch] "
+        f"detected_cuda_gpus={cuda_device_count}; fsdp_test_gpu_counts={fsdp_gpu_counts}",
+        flush=True,
+    )
+    for fsdp_num_gpus in fsdp_gpu_counts:
+        await _run_lora_logprob_match_case(
+            backend_name=backend_name,
+            fsdp_num_gpus=fsdp_num_gpus,
+            model_path=model_path,
+            tokenizer=tokenizer,
+        )
+
+
 @pytest.mark.gpu
 @pytest.mark.asyncio
 async def test_training_backend():


### PR DESCRIPTION
## Summary

- replace the VERL-backed FSDP execution path with a small torch-native FSDP2 engine
- remove the VERL and TensorDict dependencies plus their uv/install/Docker override machinery
- keep Hugging Face Accelerate as a direct dependency for the HF backend's `device_map="auto"` loading path
- validate `training_backend` as `"hf"` or `"fsdp"` through the Pydantic model
- update installation and persistence documentation for the simplified dependency path

## Why

TuFT used only a narrow part of VERL while inheriting its dependency constraints and install-time override machinery. Owning the small execution surface directly reduces packaging conflicts and maintenance overhead without changing TuFT's public training-backend interface.

## User impact

The HF backend remains the default. Users can opt into the native FSDP backend with `training_backend: fsdp`; invalid backend names now fail configuration validation instead of silently falling back to HF.

## Validation

- focused Pydantic configuration tests and Ruff checks pass
- native FSDP backend validated on Modal with 1× H100 and 2× H100, including forward/backward, optimizer steps, gradient accumulation, interleaved adapters, checkpoint save/load, and uneven distributed batch sharding
- HF backend validated on a real NVIDIA L4 with `Qwen/Qwen2.5-0.5B-Instruct` after explicitly uninstalling VERL and TensorDict
- HF validation covered two LoRA adapters, six decreasing-loss training steps, optimizer updates, and checkpoint save/load with and without optimizer state
- current wheel metadata was verified to declare Accelerate directly and omit VERL/TensorDict; the HF GPU test passed in 68.22 seconds
